### PR TITLE
Reorder Sets

### DIFF
--- a/lib/providers/workout_plans.dart
+++ b/lib/providers/workout_plans.dart
@@ -408,15 +408,13 @@ class WorkoutPlansProvider extends WgerBaseProvider with ChangeNotifier {
     notifyListeners();
   }
 
-  // Sets the order field for the given list of sets, starting from startIndex.
-  // Better than calling editSet for each set after reordering as it will notify
-  //  for every element, rebuilding for each notification.
-  Future<void> reorderSets(List<Set> sets, int startIndex) async {
+  Future<List<Set>> reorderSets(List<Set> sets, int startIndex) async {
     for (int i = startIndex; i < sets.length; i++) {
       sets[i].order = i;
       await patch(sets[i].toJson(), makeUrl(_setsUrlPath, id: sets[i].id));
     }
     notifyListeners();
+    return sets;
   }
 
   Future<void> fetchComputedSettings(Set workoutSet) async {

--- a/lib/providers/workout_plans.dart
+++ b/lib/providers/workout_plans.dart
@@ -403,6 +403,22 @@ class WorkoutPlansProvider extends WgerBaseProvider with ChangeNotifier {
     return set;
   }
 
+  Future<void> editSet(Set workoutSet) async {
+    await patch(workoutSet.toJson(), makeUrl(_setsUrlPath, id: workoutSet.id));
+    notifyListeners();
+  }
+
+  // Sets the order field for the given list of sets, starting from startIndex.
+  // Better than calling editSet for each set after reordering as it will notify
+  //  for every element, rebuilding for each notification.
+  Future<void> reorderSets(List<Set> sets, int startIndex) async {
+    for (int i = startIndex; i < sets.length; i++) {
+      sets[i].order = i;
+      await patch(sets[i].toJson(), makeUrl(_setsUrlPath, id: sets[i].id));
+    }
+    notifyListeners();
+  }
+
   Future<void> fetchComputedSettings(Set workoutSet) async {
     final data = await fetch(makeUrl(
       _setsUrlPath,

--- a/lib/widgets/workouts/day.dart
+++ b/lib/widgets/workouts/day.dart
@@ -99,6 +99,7 @@ class _WorkoutDayWidgetState extends State<WorkoutDayWidget> {
   void initState() {
     super.initState();
     _sets = widget._day.sets;
+    _sets.sort((a, b) => a.order!.compareTo(b.order!));
   }
 
   void _toggleExpanded() {
@@ -135,7 +136,12 @@ class _WorkoutDayWidgetState extends State<WorkoutDayWidget> {
             visualDensity: VisualDensity.compact,
             icon: Icon(Icons.delete),
             iconSize: ICON_SIZE_SMALL,
-            onPressed: () {
+            onPressed: () async {
+              int _startIndex = _sets.indexOf(set);
+              setState(() {
+                _sets.remove(set);
+              });
+              _sets = await Provider.of<WorkoutPlansProvider>(context, listen: false).reorderSets(_sets, _startIndex);
               Provider.of<WorkoutPlansProvider>(context, listen: false).deleteSet(set);
             },
           ),
@@ -145,7 +151,6 @@ class _WorkoutDayWidgetState extends State<WorkoutDayWidget> {
 
   @override
   Widget build(BuildContext context) {
-    _sets.sort((a, b) => a.order!.compareTo(b.order!));
     return Padding(
       padding: const EdgeInsets.only(left: 8, right: 8, bottom: 12),
       child: Card(
@@ -219,13 +224,12 @@ class _WorkoutDayWidgetState extends State<WorkoutDayWidget> {
                   _startIndex = _newIndex;
                 }
                 setState(() {
-                  final Set _set = _sets.removeAt(_oldIndex);
-                  _sets.insert(_newIndex, _set);
+                  _sets.insert(_newIndex, _sets.removeAt(_oldIndex));
                 });
-                Provider.of<WorkoutPlansProvider>(context, listen: false).reorderSets(_sets, _startIndex);
+                _sets = await Provider.of<WorkoutPlansProvider>(context, listen: false).reorderSets(_sets, _startIndex);
               },
               children: [
-                for (final _set in widget._day.sets)
+                for (final _set in _sets)
                   getSetRow(_set),
               ],
             ),

--- a/lib/widgets/workouts/day.dart
+++ b/lib/widgets/workouts/day.dart
@@ -145,6 +145,7 @@ class _WorkoutDayWidgetState extends State<WorkoutDayWidget> {
 
   @override
   Widget build(BuildContext context) {
+    _sets.sort((a, b) => a.order!.compareTo(b.order!));
     return Padding(
       padding: const EdgeInsets.only(left: 8, right: 8, bottom: 12),
       child: Card(
@@ -209,17 +210,22 @@ class _WorkoutDayWidgetState extends State<WorkoutDayWidget> {
             ReorderableListView(
               physics: NeverScrollableScrollPhysics(),
               shrinkWrap: true,
-              onReorder: (oldIndex, newIndex) {
+              onReorder: (_oldIndex, _newIndex) async {
+                int _startIndex = 0;
+                if (_oldIndex < _newIndex) {
+                  _newIndex -= 1;
+                  _startIndex = _oldIndex;
+                } else {
+                  _startIndex = _newIndex;
+                }
                 setState(() {
-                  if (oldIndex < newIndex) {
-                    newIndex -= 1;
-                  }
-                  final Set _set = _sets.removeAt(oldIndex);
-                  _sets.insert(newIndex, _set);
+                  final Set _set = _sets.removeAt(_oldIndex);
+                  _sets.insert(_newIndex, _set);
                 });
+                Provider.of<WorkoutPlansProvider>(context, listen: false).reorderSets(_sets, _startIndex);
               },
               children: [
-                for (final _set in _sets)
+                for (final _set in widget._day.sets)
                   getSetRow(_set),
               ],
             ),

--- a/lib/widgets/workouts/day.dart
+++ b/lib/widgets/workouts/day.dart
@@ -94,6 +94,13 @@ class WorkoutDayWidget extends StatefulWidget {
 
 class _WorkoutDayWidgetState extends State<WorkoutDayWidget> {
   bool _expanded = false;
+  late List<Set> _sets;
+
+  void initState() {
+    super.initState();
+    _sets = widget._day.sets;
+  }
+
   void _toggleExpanded() {
     setState(() {
       _expanded = !_expanded;
@@ -102,6 +109,7 @@ class _WorkoutDayWidgetState extends State<WorkoutDayWidget> {
 
   Widget getSetRow(Set set) {
     return Row(
+      key: ValueKey(set.id),
       crossAxisAlignment: CrossAxisAlignment.baseline,
       textBaseline: TextBaseline.alphabetic,
       children: [
@@ -198,11 +206,23 @@ class _WorkoutDayWidgetState extends State<WorkoutDayWidget> {
                 ],
               ),
             Divider(),
-            ...widget._day.sets
-                .map(
-                  (set) => getSetRow(set),
-                )
-                .toList(),
+            ReorderableListView(
+              physics: NeverScrollableScrollPhysics(),
+              shrinkWrap: true,
+              onReorder: (oldIndex, newIndex) {
+                setState(() {
+                  if (oldIndex < newIndex) {
+                    newIndex -= 1;
+                  }
+                  final Set _set = _sets.removeAt(oldIndex);
+                  _sets.insert(newIndex, _set);
+                });
+              },
+              children: [
+                for (final _set in _sets)
+                  getSetRow(_set),
+              ],
+            ),
             OutlinedButton(
               child: Text(AppLocalizations.of(context).addSet),
               onPressed: () {

--- a/lib/widgets/workouts/forms.dart
+++ b/lib/widgets/workouts/forms.dart
@@ -259,7 +259,7 @@ class SetFormWidget extends StatefulWidget {
   late Set _set;
 
   SetFormWidget(this._day, [Set? set]) {
-    this._set = set ?? Set.withData(day: _day.id, sets: 4);
+    this._set = set ?? Set.withData(day: _day.id, order: _day.sets.length, sets: 4);
   }
 
   @override


### PR DESCRIPTION
Progress PR for Issue #41.

Currently you can edit the order (long press to reorder) in the workout plan screen. The order change is only local; it persists only for the current session. I have not figured out how to reflect the changed order in the DB using the API. Does Day even store the order of its Sets in the DB? Or is it dynamically populated into the model in the app? I checked the model and its `toJSON()` ignores the Sets field. So, updating the Day using `editDay` has no effect.