### PR TITLE
Bug #53/ double displayed training plans

### DIFF
--- a/lib/screens/dashboard.dart
+++ b/lib/screens/dashboard.dart
@@ -38,88 +38,19 @@ class DashboardScreen extends StatefulWidget {
 }
 
 class _DashboardScreenState extends State<DashboardScreen> {
-  Future<void>? _initialData;
-
-  @override
-  void initState() {
-    super.initState();
-
-    // Loading data here, since the build method can be called more than once
-    _initialData = _loadEntries();
-  }
-
-  /// Load initial data from the server
-  Future<void> _loadEntries() async {
-    if (!Provider.of<AuthProvider>(context, listen: false).dataInit) {
-      Provider.of<AuthProvider>(context, listen: false).setServerVersion();
-
-      final workoutPlansProvider = Provider.of<WorkoutPlansProvider>(context, listen: false);
-      final nutritionPlansProvider = Provider.of<NutritionPlansProvider>(context, listen: false);
-      final exercisesProvider = Provider.of<ExercisesProvider>(context, listen: false);
-      final galleryProvider = Provider.of<GalleryProvider>(context, listen: false);
-      final weightProvider = Provider.of<BodyWeightProvider>(context, listen: false);
-
-      // Base data
-      await Future.wait([
-        workoutPlansProvider.fetchAndSetUnits(),
-        nutritionPlansProvider.fetchIngredientsFromCache(),
-        exercisesProvider.fetchAndSetExercises(),
-      ]);
-
-      // Plans, weight and gallery
-      await Future.wait([
-        galleryProvider.fetchAndSetGallery(),
-        nutritionPlansProvider.fetchAndSetAllPlansSparse(),
-        workoutPlansProvider.fetchAndSetAllPlansSparse(),
-        weightProvider.fetchAndSetEntries(),
-      ]);
-
-      // Current nutritional plan
-      if (nutritionPlansProvider.currentPlan != null) {
-        final plan = nutritionPlansProvider.currentPlan!;
-        await nutritionPlansProvider.fetchAndSetPlanFull(plan.id!);
-      }
-
-      // Current workout plan
-      if (workoutPlansProvider.activePlan != null) {
-        final planId = workoutPlansProvider.activePlan!.id!;
-        await workoutPlansProvider.fetchAndSetWorkoutPlanFull(planId);
-        workoutPlansProvider.setCurrentPlan(planId);
-      }
-    }
-
-    Provider.of<AuthProvider>(context, listen: false).dataInit = true;
-  }
-
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: WgerAppBar(AppLocalizations.of(context).labelDashboard),
-      body: FutureBuilder(
-        future: _initialData,
-        builder: (ctx, authResultSnapshot) =>
-            authResultSnapshot.connectionState == ConnectionState.waiting
-                ? Column(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      Text(
-                        AppLocalizations.of(context).loadingText,
-                        style: Theme.of(context).textTheme.headline5,
-                      ),
-                      Padding(padding: EdgeInsets.symmetric(vertical: 8)),
-                      LinearProgressIndicator(),
-                    ],
-                  )
-                : SingleChildScrollView(
-                    child: Column(
-                      children: [
-                        DashboardWorkoutWidget(),
-                        DashboardNutritionWidget(),
-                        DashboardWeightWidget(),
-                        DashboardCalendarWidget(),
-                      ],
-                    ),
-                  ),
+      body: SingleChildScrollView(
+        child: Column(
+          children: [
+            DashboardWorkoutWidget(),
+            DashboardNutritionWidget(),
+            DashboardWeightWidget(),
+            DashboardCalendarWidget(),
+          ],
+        ),
       ),
     );
   }

--- a/lib/widgets/workouts/forms.dart
+++ b/lib/widgets/workouts/forms.dart
@@ -709,10 +709,10 @@ class WeightInputWidget extends StatelessWidget {
 /// Can be used with a Setting or a Log object
 class RiRInputWidget extends StatefulWidget {
   final dynamic _setting;
-  late String dropdownValue;
-  late double _currentSetSliderValue;
+  late final String dropdownValue;
+  late final double _currentSetSliderValue;
 
-  final SLIDER_START = -0.5;
+  static const SLIDER_START = -0.5;
 
   RiRInputWidget(this._setting) {
     dropdownValue = _setting.rir != null ? _setting.rir : Setting.DEFAULT_RIR;
@@ -764,7 +764,7 @@ class _RiRInputWidgetState extends State<RiRInputWidget> {
         Expanded(
           child: Slider(
             value: widget._currentSetSliderValue,
-            min: widget.SLIDER_START,
+            min: RiRInputWidget.SLIDER_START,
             max: (Setting.POSSIBLE_RIR_VALUES.length - 2) / 2,
             divisions: Setting.POSSIBLE_RIR_VALUES.length - 1,
             label: getSliderLabel(widget._currentSetSliderValue),


### PR DESCRIPTION
Fixes #53 

Moved the FutureBuilder from dashboard.dart to home_tabs_screen.dart

At the moment the navigation bar is still shown, we can consider to also move it into the future builder and to show a nice splashscreen instead of the LinearProgressIndicator.

