### PR TITLE
Fixed Infinite loader bug

### DIFF
--- a/lib/screens/auth_screen.dart
+++ b/lib/screens/auth_screen.dart
@@ -147,6 +147,9 @@ class _AuthCardState extends State<AuthCard> {
       });
     } on WgerHttpException catch (error) {
       showHttpExceptionErrorDialog(error, context);
+      setState(() {
+        _isLoading = false;
+      });
     } catch (error) {
       showErrorDialog(error, context);
       setState(() {


### PR DESCRIPTION
# Proposed Changes

- I have added a `setState` callback to set the `loading` state to false inside the catch block. This way every time an Exception or an error is caught, it will stop the circular loader.

Related Issues (if applicable)

- Fixes issue #95 

## Please check that the PR fulfills these requirements

- [x] Set a 100 character limit in your editor/IDE to avoid white space diffs in the PR
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Added yourself to AUTHORS.rst
