### PR TITLE
Fix for RiR slider

### DIFF
--- a/lib/widgets/workouts/forms.dart
+++ b/lib/widgets/workouts/forms.dart
@@ -771,6 +771,8 @@ class RiRInputWidget extends StatefulWidget {
 }
 
 class _RiRInputWidgetState extends State<RiRInputWidget> {
+  late double currentSetSliderValueMutable = widget._currentSetSliderValue;
+
   /// Returns the string used in the slider
   String getSliderLabel(double value) {
     if (value < 0) {
@@ -800,15 +802,15 @@ class _RiRInputWidgetState extends State<RiRInputWidget> {
         Text(AppLocalizations.of(context).rir),
         Expanded(
           child: Slider(
-            value: widget._currentSetSliderValue,
+            value: currentSetSliderValueMutable,
             min: RiRInputWidget.SLIDER_START,
             max: (Setting.POSSIBLE_RIR_VALUES.length - 2) / 2,
             divisions: Setting.POSSIBLE_RIR_VALUES.length - 1,
-            label: getSliderLabel(widget._currentSetSliderValue),
+            label: getSliderLabel(currentSetSliderValueMutable),
             onChanged: (double value) {
               widget._setting.setRir(mapDoubleToAllowedRir(value));
               setState(() {
-                widget._currentSetSliderValue = value;
+                currentSetSliderValueMutable = value;
               });
             },
           ),

--- a/lib/widgets/workouts/forms.dart
+++ b/lib/widgets/workouts/forms.dart
@@ -746,8 +746,8 @@ class WeightInputWidget extends StatelessWidget {
 /// Can be used with a Setting or a Log object
 class RiRInputWidget extends StatefulWidget {
   final dynamic _setting;
-  late final String dropdownValue;
-  late final double _currentSetSliderValue;
+  late String dropdownValue;
+  late double _currentSetSliderValue;
 
   static const SLIDER_START = -0.5;
 
@@ -771,8 +771,6 @@ class RiRInputWidget extends StatefulWidget {
 }
 
 class _RiRInputWidgetState extends State<RiRInputWidget> {
-  late double currentSetSliderValueMutable = widget._currentSetSliderValue;
-
   /// Returns the string used in the slider
   String getSliderLabel(double value) {
     if (value < 0) {
@@ -802,15 +800,15 @@ class _RiRInputWidgetState extends State<RiRInputWidget> {
         Text(AppLocalizations.of(context).rir),
         Expanded(
           child: Slider(
-            value: currentSetSliderValueMutable,
+            value: widget._currentSetSliderValue,
             min: RiRInputWidget.SLIDER_START,
             max: (Setting.POSSIBLE_RIR_VALUES.length - 2) / 2,
             divisions: Setting.POSSIBLE_RIR_VALUES.length - 1,
-            label: getSliderLabel(currentSetSliderValueMutable),
+            label: getSliderLabel(widget._currentSetSliderValue),
             onChanged: (double value) {
               widget._setting.setRir(mapDoubleToAllowedRir(value));
               setState(() {
-                currentSetSliderValueMutable = value;
+                widget._currentSetSliderValue = value;
               });
             },
           ),


### PR DESCRIPTION
# Proposed Changes

- When trying to move the slide on slider in RiR, there were initialization errors (#103)

The RiR slider value was a final variable so it couldn't be reassigned and reinitialized the value. I changed to use the final variable only on first initialization, for the rest of the slider using I made a temp variable that isn't final so everything works as it supposed to..

## Please check that the PR fulfills these requirements

- [ ] Set a 100 character limit in your editor/IDE to avoid white space diffs in the PR
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Added yourself to AUTHORS.md
