### PR TITLE
Fix sub-url handling

### DIFF
--- a/lib/providers/helpers.dart
+++ b/lib/providers/helpers.dart
@@ -26,7 +26,7 @@ Uri makeUri(
 ]) {
   final Uri uriServer = Uri.parse(serverUrl);
 
-  final pathList = ['api', 'v2', path];
+  final pathList = [uriServer.path, 'api', 'v2', path];
   if (id != null) {
     pathList.add(id.toString());
   }

--- a/test/other/base_provider_test.dart
+++ b/test/other/base_provider_test.dart
@@ -58,5 +58,40 @@ void main() {
         provider.makeUrl('endpoint', id: 42, objectMethod: 'log_data', query: {'a': '2', 'b': 'c'}),
       );
     });
+
+    test('Test the makeUrl helper with sub url', () async {
+      // Trailing slash is removed when saving the server URL
+      testAuthProvider.serverUrl = 'https://example.com/wger-url';
+      final WgerBaseProvider provider = WgerBaseProvider(testAuthProvider);
+
+      expect(
+        Uri.https('example.com', '/wger-url/api/v2/endpoint/'),
+        provider.makeUrl('endpoint'),
+      );
+      expect(
+        Uri.https('example.com', '/wger-url/api/v2/endpoint/5/'),
+        provider.makeUrl('endpoint', id: 5),
+      );
+      expect(
+        Uri.https('example.com', '/wger-url/api/v2/endpoint/5/log_data/'),
+        provider.makeUrl('endpoint', id: 5, objectMethod: 'log_data'),
+      );
+      expect(
+        Uri.https('example.com', '/wger-url/api/v2/endpoint/', {'a': '2', 'b': 'c'}),
+        provider.makeUrl('endpoint', query: {'a': '2', 'b': 'c'}),
+      );
+      expect(
+        Uri.https('example.com', '/wger-url/api/v2/endpoint/log_data/', {'a': '2', 'b': 'c'}),
+        provider.makeUrl('endpoint', objectMethod: 'log_data', query: {'a': '2', 'b': 'c'}),
+      );
+      expect(
+        Uri.https('example.com', '/wger-url/api/v2/endpoint/42/', {'a': '2', 'b': 'c'}),
+        provider.makeUrl('endpoint', id: 42, query: {'a': '2', 'b': 'c'}),
+      );
+      expect(
+        Uri.https('example.com', '/wger-url/api/v2/endpoint/42/log_data/', {'a': '2', 'b': 'c'}),
+        provider.makeUrl('endpoint', id: 42, objectMethod: 'log_data', query: {'a': '2', 'b': 'c'}),
+      );
+    });
   });
 }


### PR DESCRIPTION
Previously the app was unable to work with instances installed on sub-urls
because sub-url path was removed (say, server.name/api/v2/login instead of
server.name/wger/api/v2/login).

Related Issues: https://github.com/wger-project/flutter/issues/193
