### PR TITLE
Add measurement unit to entry form

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -13,6 +13,7 @@
 - Marko Milosevic - <https://github.com/TaarnStar>
 - Karthik Reddy (Axel) - <https://github.com/AxelBlaz3>
 - Ogundoyin Toluwani - <https://github.com/Tolu007>
+- Florian Schmitz - <https://github.com/floodoo>
 
 ## Translators
 

--- a/lib/widgets/measurements/forms.dart
+++ b/lib/widgets/measurements/forms.dart
@@ -156,6 +156,11 @@ class MeasurementEntryForm extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final measurementProvider = Provider.of<MeasurementProvider>(context, listen: false);
+    final measurementCategory = measurementProvider.categories.firstWhere(
+      (category) => category.id == _categoryId,
+    );
+
     return Form(
       key: _form,
       child: Column(
@@ -199,7 +204,11 @@ class MeasurementEntryForm extends StatelessWidget {
           ),
           // Value
           TextFormField(
-            decoration: InputDecoration(labelText: AppLocalizations.of(context).value),
+            decoration: InputDecoration(
+              labelText: AppLocalizations.of(context).value,
+              suffixIcon: Text(measurementCategory.unit),
+              suffixIconConstraints: const BoxConstraints(minWidth: 0, minHeight: 0),
+            ),
             controller: _valueController,
             keyboardType: TextInputType.number,
             validator: (value) {


### PR DESCRIPTION
# Proposed Changes

- In the MeasurementEntryForm Widget, I read the MeasurementProvider to get the current measurement category. After that, I can get the unit of the category to display it as a suffix Widget

<img width="402" alt="Bildschirmfoto 2022-09-27 um 14 46 06" src="https://user-images.githubusercontent.com/59688267/192530050-e7d367f6-1154-40ef-8016-1a849c1e5e2c.png">


Related Issues (if applicable)

- https://github.com/wger-project/flutter/issues/231

## Please check that the PR fulfills these requirements

- [x] Set a 100 character limit in your editor/IDE to avoid white space diffs in the PR
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Added yourself to AUTHORS.md
