### PR TITLE
Update theme.dart

### DIFF
--- a/lib/theme/theme.dart
+++ b/lib/theme/theme.dart
@@ -95,7 +95,9 @@ final ThemeData wgerTheme = ThemeData(
      */
   textButtonTheme: TextButtonThemeData(
     style: TextButton.styleFrom(
-      primary: wgerPrimaryButtonColor,
+//       This primary is deprecated and should not be used
+//       primary: wgerPrimaryButtonColor,
+      foregroundColor: wgerPrimaryButtonColor,
     ),
   ),
   outlinedButtonTheme: OutlinedButtonThemeData(


### PR DESCRIPTION
The primary is deprecated and should not be used. We can change that to foreground color

# Proposed Changes

-
-
-

Related Issues (if applicable)

-

## Please check that the PR fulfills these requirements

- [x] Set a 100 character limit in your editor/IDE to avoid white space diffs in the PR
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Added yourself to AUTHORS.md
