### PR TITLE
Fix rendering of muscles in MuscleWidget

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -22,6 +22,7 @@
 - Miroslav Mazel - <https://gitlab.com/12people>
 - artchiee - <https://github.com/artchiee>
 - Tejas Bir Singh - <https://github.com/tejasbirsingh>
+- Youssef Ahmed - <https://github.com/thisisyoussef>
 
 ## Translators
 
@@ -56,7 +57,7 @@
 - Norwegian Bokmål
 
   - Allan Nordhøy <epost@anotheragency.no> (98)
-  
+
 - Japanese
 
   - Kosei TANAKA <wms784.app@gmail.com> (97)
@@ -66,5 +67,5 @@
   - Nenza Nurfirmansyah <nnurfirmansyah@gmail.com> (73)
 
 - Croatian
-  
+
   - Sandi Milohaic <sandi.milohanic@gmail.com>

--- a/lib/widgets/exercises/exercises.dart
+++ b/lib/widgets/exercises/exercises.dart
@@ -42,7 +42,8 @@ class ExerciseDetail extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    _exercise = _exerciseBase.getExercise(Localizations.localeOf(context).languageCode);
+    _exercise =
+        _exerciseBase.getExercise(Localizations.localeOf(context).languageCode);
 
     return SingleChildScrollView(
       child: Column(
@@ -156,7 +157,9 @@ class ExerciseDetail extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           const MuscleColorHelper(main: true),
-          ..._exerciseBase.muscles.map((e) => Text(e.nameTranslated(context))).toList(),
+          ..._exerciseBase.muscles
+              .map((e) => Text(e.nameTranslated(context)))
+              .toList(),
         ],
       ),
     );
@@ -219,7 +222,9 @@ class ExerciseDetail extends StatelessWidget {
     // TODO: add carousel for the other videos
     final List<Widget> out = [];
     if (_exerciseBase.videos.isNotEmpty && !isDesktop) {
-      _exerciseBase.videos.map((v) => ExerciseVideoWidget(video: v)).forEach((element) {
+      _exerciseBase.videos
+          .map((v) => ExerciseVideoWidget(video: v))
+          .forEach((element) {
         out.add(element);
       });
 
@@ -232,8 +237,8 @@ class ExerciseDetail extends StatelessWidget {
     final List<Widget> out = [];
     if (_exercise.alias.isNotEmpty) {
       out.add(MutedText(
-        AppLocalizations.of(context)
-            .alsoKnownAs(_exercise.alias.map((e) => e.alias).toList().join(', ')),
+        AppLocalizations.of(context).alsoKnownAs(
+            _exercise.alias.map((e) => e.alias).toList().join(', ')),
       ));
       out.add(const SizedBox(height: PADDING));
     }
@@ -275,7 +280,8 @@ class MuscleRowWidget extends StatelessWidget {
   final List<Muscle> muscles;
   final List<Muscle> musclesSecondary;
 
-  const MuscleRowWidget({required this.muscles, required this.musclesSecondary});
+  const MuscleRowWidget(
+      {required this.muscles, required this.musclesSecondary});
 
   @override
   Widget build(BuildContext context) {
@@ -319,7 +325,8 @@ class MuscleWidget extends StatelessWidget {
     this.isFront = true,
   }) {
     this.muscles = muscles.where((m) => m.isFront == isFront).toList();
-    this.musclesSecondary = musclesSecondary.where((m) => m.isFront == isFront).toList();
+    this.musclesSecondary =
+        musclesSecondary.where((m) => m.isFront == isFront).toList();
   }
 
   @override
@@ -330,10 +337,13 @@ class MuscleWidget extends StatelessWidget {
       children: [
         SvgPicture.asset('assets/images/muscles/$background.svg'),
         ...muscles
-            .map((m) => SvgPicture.asset('assets/images/muscles/main/muscle-${m.id}.svg'))
+            .map((m) => SvgPicture.asset(
+                'assets/images/muscles/main/muscle-${m.id}.svg'))
             .toList(),
         ...musclesSecondary
-            .map((m) => SvgPicture.asset('assets/images/muscles/secondary/muscle-${m.id}.svg'))
+            .where((m) => !muscles.contains(m))
+            .map((m) => SvgPicture.asset(
+                'assets/images/muscles/secondary/muscle-${m.id}.svg'))
             .toList(),
       ],
     );


### PR DESCRIPTION
Ensure that when a muscle is both main and secondary, only the main muscle background is drawn. This addresses potential overlaps and redundant rendering in the MuscleWidget.

# Proposed Changes

-Updated the build method in MuscleWidget to filter out secondary muscles that are also present in the main muscles list before rendering.
-By doing so, we prevent the same muscle from being rendered twice, ensuring that only the main muscle background is displayed.
-This approach retains the structure and readability of the code while addressing the issue.


## Please check that the PR fulfills these requirements

- [X] Set a 100 character limit in your editor/IDE to avoid white space diffs in the PR
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Added yourself to AUTHORS.md
