### PR TITLE
Add support for themed icon on Android 13+

### DIFF
--- a/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
   <background android:drawable="@color/ic_launcher_background"/>
   <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+  <monochrome android:drawable="@mipmap/ic_launcher_monochrome" />
 </adaptive-icon>


### PR DESCRIPTION
## Description (Proposed Changes)

Since Android 13, users can enable themed icons on their home screen.
Example:
![image](https://github.com/wger-project/flutter/assets/71343264/192e573b-6a0a-49e8-bf8a-3af421a6259e)


- Added themed icon support for devices running Android 13 and above.
-

## Link to the issue : 

None.

## Tests

Not needed.

## Checklist

Please check that the PR fulfills all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] Set a 100 character limit in your editor/IDE to avoid white space diffs in the PR
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Added yourself to AUTHORS.md
- [x] Updated/added relevant documentation (doc comments with `///`).
- [x] Added relevant reviewers.
