### PR TITLE
Improve flatpak local build

### DIFF
--- a/flatpak/scripts/README.md
+++ b/flatpak/scripts/README.md
@@ -9,11 +9,15 @@ If uploading to Flathub for the first time, follow the official contributing gui
 
 To run a local build:
 
-1. Build the Linux release using Flutter.
+1. Build the Linux release using Flutter. `flutter build linux --release`
 2. Add the new release version and date to the start of the "releases" list in the "spec.json" file (and adjust other parameters in the file if needed).
-3. Run "dart flatpak_packager.dart --meta ../flatpak_meta.json -n pubspec.yaml" in this folder.
-4. Run "dart manifest_generator.dart --meta ../flatpak_meta.json -n pubspec.yaml" in this folder.
+3. Run `dart flatpak_packager.dart --meta ../flatpak_meta.json -n pubspec.yaml` in this folder.
+4. Run `dart manifest_generator.dart --meta ../flatpak_meta.json -n pubspec.yaml` in this folder.
 5. Test the Flatpak using the guide at https://docs.flatpak.org/en/latest/first-build.html, using the generated json manifest as your Flatpak manifest.
+```bash
+cd flatpak_generator_exports
+flatpak-builder --user --install flatpak-build-dir de.wger.flutter.json
+```
 
 # Builds based on data fetched from Github
 
@@ -21,9 +25,9 @@ To generate and publish a release on Github:
 
 1. Create a new release on Github using the app's version name for the tag (e.g. "1.0.0"), without any assets for now.
 2. Build the Linux release using Flutter.
-3. Run "dart flatpak_packager.dart --meta ../flatpak_meta.json --github -n pubspec.yaml" in this folder.
+3. Run `dart flatpak_packager.dart --meta ../flatpak_meta.json --github -n pubspec.yaml` in this folder.
 4. Upload the generated tar.gz file as a Github release.
-5. Run "dart manifest_generator.dart --meta ../flatpak_meta.json --github -n pubspec.yaml" in this folder.
+5. Run `dart manifest_generator.dart --meta ../flatpak_meta.json --github -n pubspec.yaml` in this folder.
 6. Upload your Flathub manifest file to your Flathub Github repo, overwriting any old manifest file you may have there. If you're building for only certain architectures and the "flathub.json" file is not in your Flathub Github repo yet, upload that too.
 
 All of this can be automated via Github Actions.

--- a/flatpak/scripts/flatpak_packager.dart
+++ b/flatpak/scripts/flatpak_packager.dart
@@ -116,6 +116,10 @@ class PackageGenerator {
 
     shaByArch.putIfAbsent(arch, () => sha256);
 
+    final localReleaseAssetsFile = await File('${outputDir.path}/local_release_assets.json')
+      .writeAsString('[{"arch": "${arch.flatpakArchCode}", "tarballPath": "$packagePath"}]');
+    print('Generated ${localReleaseAssetsFile.path}');
+
     tempDir.deleteSync(recursive: true);
   }
 

--- a/flatpak/scripts/flatpak_shared.dart
+++ b/flatpak/scripts/flatpak_shared.dart
@@ -249,6 +249,12 @@ class FlatpakMeta {
   static FlatpakMeta fromJson(File jsonFile) {
     try {
       final dynamic json = jsonDecode(jsonFile.readAsStringSync());
+      final localReleaseAssetsFile = File(
+        '${Directory.current.path}/flatpak_generator_exports/local_release_assets.json'
+      );
+      if (localReleaseAssetsFile.existsSync()) {
+        json['localReleaseAssets'] = jsonDecode(localReleaseAssetsFile.readAsStringSync());
+      }
       return FlatpakMeta(
           appId: json['appId'] as String,
           lowercaseAppName: json['lowercaseAppName'] as String,
@@ -270,7 +276,7 @@ class FlatpakMeta {
               throw Exception(
                   'Architecture must be either "${CPUArchitecture.x86_64.flatpakArchCode}" or "${CPUArchitecture.aarch64.flatpakArchCode}"');
             }
-            final tarballPath = '${jsonFile.parent.path}/${raMap['tarballPath'] as String}';
+            final tarballPath = raMap['tarballPath'] as String;
             final preShasum = Process.runSync('shasum', ['-a', '256', tarballPath]);
             final shasum = preShasum.stdout.toString().split(' ').first;
             if (preShasum.exitCode != 0) {


### PR DESCRIPTION
## Description (Proposed Changes)

For `flatpak_packager.dart` `localReleaseAssets` in  `flatpak_meta.json`  needs to be empty (kind of). But for `manifest_generator.dart` it needs to be filled correctly otherwise the flatpak manifest will not be correct.

So i handled the data in a seperate json file.


## Checklist

Please check that the PR fulfills all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] Set a 100 character limit in your editor/IDE to avoid white space diffs in the PR
- [-] Tests for the changes have been added (for bug fixes / features)
- [-] Added yourself to AUTHORS.md <- not in application code
- [x] Updated/added relevant documentation (doc comments with `///`).
- [ ] Added relevant reviewers.
