### PR TITLE
448 fix flaky test

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -25,6 +25,7 @@
 - Abhishek Saini - <https://github.com/Abhisheksainii>
 - Hanaa Allohibi - <https://github.com/hn-n>
 - Shey Alnasrawi - <https://github.com/Milksheyke>
+- Costas Korai - <https://github.com/watcher6280>
 
 ## Translators
 

--- a/lib/models/nutrition/meal.dart
+++ b/lib/models/nutrition/meal.dart
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import 'package:clock/clock.dart';
 import 'package:flutter/material.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:wger/helpers/json.dart';
@@ -54,7 +55,7 @@ class Meal {
 
     this.mealItems = mealItems ?? [];
 
-    this.time = time ?? TimeOfDay.now();
+    this.time = time ?? TimeOfDay.fromDateTime(clock.now());
     this.name = name ?? '';
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -67,6 +67,7 @@ dependencies:
   flex_seed_scheme: ^1.4.0
   flex_color_scheme: ^7.3.1
   freezed_annotation: ^2.4.1
+  clock: ^1.1.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Description (Proposed Changes)
- Start using the clock package https://pub.dev/packages/clock when referencing the current time.
- Initially only applied to make one unit test stable.

## Link to the issue : 
https://github.com/wger-project/flutter/issues/448

## Checklist

Please check that the PR fulfills all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] Set a 100 character limit in your editor/IDE to avoid white space diffs in the PR
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Added yourself to AUTHORS.md
- [x] Updated/added relevant documentation (doc comments with `///`).
- [ ] Added relevant reviewers.
