### PR TITLE
Add energy and kcal values to ingredient logging/adding forms

### DIFF
--- a/lib/models/nutrition/ingredient.dart
+++ b/lib/models/nutrition/ingredient.dart
@@ -18,6 +18,7 @@
 import 'package:json_annotation/json_annotation.dart';
 import 'package:wger/helpers/json.dart';
 import 'package:wger/models/nutrition/image.dart';
+import 'package:wger/models/nutrition/nutritional_values.dart';
 
 part 'ingredient.g.dart';
 
@@ -91,4 +92,17 @@ class Ingredient {
   factory Ingredient.fromJson(Map<String, dynamic> json) => _$IngredientFromJson(json);
 
   Map<String, dynamic> toJson() => _$IngredientToJson(this);
+
+  NutritionalValues get nutritionalValues {
+    return NutritionalValues.values(
+      energy * 1,
+      protein * 1,
+      carbohydrates * 1,
+      carbohydratesSugar * 1,
+      fat * 1,
+      fatSaturated * 1,
+      fibres * 1,
+      sodium * 1,
+    );
+  }
 }

--- a/lib/models/nutrition/log.dart
+++ b/lib/models/nutrition/log.dart
@@ -83,21 +83,10 @@ class Log {
   /// Calculations
   NutritionalValues get nutritionalValues {
     // This is already done on the server. It might be better to read it from there.
-    final out = NutritionalValues();
 
-    //final weight = amount;
     final weight =
         weightUnitObj == null ? amount : amount * weightUnitObj!.amount * weightUnitObj!.grams;
 
-    out.energy = ingredient.energy * weight / 100;
-    out.protein = ingredient.protein * weight / 100;
-    out.carbohydrates = ingredient.carbohydrates * weight / 100;
-    out.carbohydratesSugar = ingredient.carbohydratesSugar * weight / 100;
-    out.fat = ingredient.fat * weight / 100;
-    out.fatSaturated = ingredient.fatSaturated * weight / 100;
-    out.fibres = ingredient.fibres * weight / 100;
-    out.sodium = ingredient.sodium * weight / 100;
-
-    return out;
+    return ingredient.nutritionalValues / (100 / weight);
   }
 }

--- a/lib/models/nutrition/meal_item.dart
+++ b/lib/models/nutrition/meal_item.dart
@@ -72,6 +72,7 @@ class MealItem {
   Map<String, dynamic> toJson() => _$MealItemToJson(this);
 
   /// Calculations
+  /// TODO why does this not consider weightUnitObj ? should we do the same as Log.nutritionalValues here?
   NutritionalValues get nutritionalValues {
     // This is already done on the server. It might be better to read it from there.
     final out = NutritionalValues();

--- a/lib/widgets/dashboard/widgets.dart
+++ b/lib/widgets/dashboard/widgets.dart
@@ -42,6 +42,7 @@ import 'package:wger/widgets/measurements/charts.dart';
 import 'package:wger/widgets/measurements/forms.dart';
 import 'package:wger/widgets/nutrition/charts.dart';
 import 'package:wger/widgets/nutrition/forms.dart';
+import 'package:wger/widgets/nutrition/helpers.dart';
 import 'package:wger/widgets/weight/forms.dart';
 import 'package:wger/widgets/workouts/forms.dart';
 
@@ -83,23 +84,7 @@ class _DashboardNutritionWidgetState extends State<DashboardNutritionWidget> {
                   //textAlign: TextAlign.left,
                 ),
               ),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceAround,
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  MutedText(
-                      '${AppLocalizations.of(context).energyShort} ${meal.plannedNutritionalValues.energy.toStringAsFixed(0)}${AppLocalizations.of(context).kcal}'),
-                  const MutedText(' / '),
-                  MutedText(
-                      '${AppLocalizations.of(context).proteinShort} ${meal.plannedNutritionalValues.protein.toStringAsFixed(0)}${AppLocalizations.of(context).g}'),
-                  const MutedText(' / '),
-                  MutedText(
-                      '${AppLocalizations.of(context).carbohydratesShort} ${meal.plannedNutritionalValues.carbohydrates.toStringAsFixed(0)}${AppLocalizations.of(context).g}'),
-                  const MutedText(' / '),
-                  MutedText(
-                      '${AppLocalizations.of(context).fatShort} ${meal.plannedNutritionalValues.fat.toStringAsFixed(0)}${AppLocalizations.of(context).g} '),
-                ],
-              ),
+              MutedText(getShortNutritionValues(meal.plannedNutritionalValues, context)),
               IconButton(
                 icon: const Icon(Icons.history_edu),
                 color: wgerPrimaryButtonColor,

--- a/lib/widgets/nutrition/forms.dart
+++ b/lib/widgets/nutrition/forms.dart
@@ -368,9 +368,9 @@ class _IngredientLogFormState extends State<IngredientLogForm> {
                       builder: (BuildContext context, AsyncSnapshot<Ingredient> snapshot) {
                         if (snapshot.hasData) {
                           _mealItem.ingredient = snapshot.data!;
-                          return Padding(
-                            padding: const EdgeInsets.only(top: 16),
-                            child:
+                          return ListTile(
+                            leading: IngredientAvatar(ingredient: _mealItem.ingredient),
+                            title:
                                 Text(getShortNutritionValues(_mealItem.nutritionalValues, context)),
                           );
                         } else if (snapshot.hasError) {

--- a/lib/widgets/nutrition/forms.dart
+++ b/lib/widgets/nutrition/forms.dart
@@ -28,6 +28,7 @@ import 'package:wger/models/nutrition/meal_item.dart';
 import 'package:wger/models/nutrition/nutritional_plan.dart';
 import 'package:wger/providers/nutrition.dart';
 import 'package:wger/screens/nutritional_plan_screen.dart';
+import 'package:wger/widgets/nutrition/helpers.dart';
 import 'package:wger/widgets/nutrition/widgets.dart';
 
 class MealForm extends StatelessWidget {
@@ -210,8 +211,10 @@ class MealItemForm extends StatelessWidget {
                         _mealItem.ingredientId = _listMealItems[index].ingredientId;
                         _mealItem.amount = _listMealItems[index].amount;
                       },
-                      title: Text(_listMealItems[index].ingredient.name),
-                      subtitle: Text('${_listMealItems[index].amount.toStringAsFixed(0)}$unit'),
+                      title: Text(
+                          '${_listMealItems[index].ingredient.name} (${_listMealItems[index].amount.toStringAsFixed(0)}$unit)'),
+                      subtitle: Text(getShortNutritionValues(
+                          _listMealItems[index].ingredient.nutritionalValues, context)),
                       trailing: const Icon(Icons.copy),
                     ),
                   );
@@ -376,8 +379,10 @@ class IngredientLogForm extends StatelessWidget {
                         _mealItem.ingredientId = diaryEntries[index].ingredientId;
                         _mealItem.amount = diaryEntries[index].amount;
                       },
-                      title: Text(_plan.diaryEntries[index].ingredient.name),
-                      subtitle: Text('${diaryEntries[index].amount.toStringAsFixed(0)}$unit'),
+                      title: Text(
+                          '${diaryEntries[index].ingredient.name} (${diaryEntries[index].amount.toStringAsFixed(0)}$unit)'),
+                      subtitle: Text(getShortNutritionValues(
+                          diaryEntries[index].ingredient.nutritionalValues, context)),
                       trailing: const Icon(Icons.copy),
                     ),
                   );

--- a/lib/widgets/nutrition/forms.dart
+++ b/lib/widgets/nutrition/forms.dart
@@ -157,10 +157,10 @@ class IngredientForm extends StatefulWidget {
   });
 
   @override
-  State<IngredientForm> createState() => _IngredientFormState();
+  State<IngredientForm> createState() => IngredientFormState();
 }
 
-class _IngredientFormState extends State<IngredientForm> {
+class IngredientFormState extends State<IngredientForm> {
   final _form = GlobalKey<FormState>();
   final _ingredientController = TextEditingController();
   final _ingredientIdController = TextEditingController();
@@ -209,7 +209,10 @@ class _IngredientFormState extends State<IngredientForm> {
                     onFieldSubmitted: (_) {},
                     onChanged: (value) {
                       setState(() {
-                        _mealItem.amount = double.tryParse(value) ?? _mealItem.amount;
+                        final v = double.tryParse(value);
+                        if (v != null) {
+                          _mealItem.amount = v;
+                        }
                       });
                     },
                     onSaved: (value) {

--- a/lib/widgets/nutrition/helpers.dart
+++ b/lib/widgets/nutrition/helpers.dart
@@ -40,3 +40,12 @@ List<Widget> getMutedNutritionalValues(NutritionalValues values, BuildContext co
         textAlign: TextAlign.right,
       ),
     ];
+
+String getShortNutritionValues(NutritionalValues values, BuildContext context) {
+  final loc = AppLocalizations.of(context);
+  final e = '${loc.energyShort} ${loc.kcalValue(values.energy.toStringAsFixed(0))}';
+  final p = '${loc.proteinShort} ${loc.gValue(values.protein.toStringAsFixed(0))}';
+  final c = '${loc.carbohydratesShort} ${loc.gValue(values.carbohydrates.toStringAsFixed(0))}';
+  final f = '${loc.fatShort} ${loc.gValue(values.fat.toStringAsFixed(0))}';
+  return '$e / $p / $c / $f';
+}

--- a/lib/widgets/nutrition/meal.dart
+++ b/lib/widgets/nutrition/meal.dart
@@ -20,13 +20,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
 import 'package:wger/helpers/consts.dart';
-import 'package:wger/helpers/misc.dart';
 import 'package:wger/models/nutrition/log.dart';
 import 'package:wger/models/nutrition/meal.dart';
 import 'package:wger/models/nutrition/meal_item.dart';
 import 'package:wger/providers/nutrition.dart';
 import 'package:wger/screens/form_screen.dart';
-import 'package:wger/widgets/core/core.dart';
 import 'package:wger/widgets/nutrition/charts.dart';
 import 'package:wger/widgets/nutrition/forms.dart';
 import 'package:wger/widgets/nutrition/helpers.dart';
@@ -208,18 +206,7 @@ class MealItemWidget extends StatelessWidget {
     final values = _item.nutritionalValues;
 
     return ListTile(
-      leading: _item.ingredient.image != null
-          ? GestureDetector(
-              child: CircleAvatar(backgroundImage: NetworkImage(_item.ingredient.image!.image)),
-              onTap: () async {
-                if (_item.ingredient.image!.objectUrl != '') {
-                  return launchURL(_item.ingredient.image!.objectUrl, context);
-                } else {
-                  return;
-                }
-              },
-            )
-          : const CircleIconAvatar(Icon(Icons.image, color: Colors.grey)),
+      leading: IngredientAvatar(ingredient: _item.ingredient),
       title: Text(
         '${_item.amount.toStringAsFixed(0)}$unit ${_item.ingredient.name}',
         overflow: TextOverflow.ellipsis,
@@ -273,18 +260,7 @@ class LogDiaryItemWidget extends StatelessWidget {
     final values = _item.nutritionalValues;
 
     return ListTile(
-      leading: _item.ingredient.image != null
-          ? GestureDetector(
-              child: CircleAvatar(backgroundImage: NetworkImage(_item.ingredient.image!.image)),
-              onTap: () async {
-                if (_item.ingredient.image!.objectUrl != '') {
-                  return launchURL(_item.ingredient.image!.objectUrl, context);
-                } else {
-                  return;
-                }
-              },
-            )
-          : const CircleIconAvatar(Icon(Icons.image, color: Colors.grey)),
+      leading: IngredientAvatar(ingredient: _item.ingredient),
       title: Text(
         '${_item.amount.toStringAsFixed(0)}$unit ${_item.ingredient.name}',
         overflow: TextOverflow.ellipsis,

--- a/lib/widgets/nutrition/widgets.dart
+++ b/lib/widgets/nutrition/widgets.dart
@@ -25,9 +25,11 @@ import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 import 'package:wger/helpers/consts.dart';
+import 'package:wger/helpers/misc.dart';
 import 'package:wger/helpers/platform.dart';
 import 'package:wger/helpers/ui.dart';
 import 'package:wger/models/exercises/ingredient_api.dart';
+import 'package:wger/models/nutrition/ingredient.dart';
 import 'package:wger/models/nutrition/log.dart';
 import 'package:wger/models/nutrition/nutritional_plan.dart';
 import 'package:wger/providers/nutrition.dart';
@@ -333,5 +335,25 @@ class NutritionDiaryEntry extends StatelessWidget {
               icon: const Icon(Icons.delete_outline)),
       ],
     );
+  }
+}
+
+class IngredientAvatar extends StatelessWidget {
+  final Ingredient ingredient;
+
+  const IngredientAvatar({super.key, required this.ingredient});
+
+  @override
+  Widget build(BuildContext context) {
+    return ingredient.image != null
+        ? GestureDetector(
+            child: CircleAvatar(backgroundImage: NetworkImage(ingredient.image!.image)),
+            onTap: () async {
+              if (ingredient.image!.objectUrl != '') {
+                return launchURL(ingredient.image!.objectUrl, context);
+              }
+            },
+          )
+        : const CircleIconAvatar(Icon(Icons.image, color: Colors.grey));
   }
 }

--- a/test/nutrition/nutritional_meal_item_form_test.dart
+++ b/test/nutrition/nutritional_meal_item_form_test.dart
@@ -101,7 +101,7 @@ void main() {
         home: Scaffold(
           body: Scrollable(
             viewportBuilder: (BuildContext context, ViewportOffset position) =>
-                MealItemForm(meal, const [], null, code, test),
+                MealItemForm(meal, const [], code, test),
           ),
         ),
         routes: {
@@ -213,7 +213,7 @@ void main() {
     testWidgets('confirm found ingredient dialog', (WidgetTester tester) async {
       await tester.pumpWidget(createMealItemFormScreen(meal1, '123', true));
 
-      final MealItemForm formScreen = tester.widget(find.byType(MealItemForm));
+      final IngredientForm formScreen = tester.widget(find.byType(IngredientForm));
 
       await tester.tap(find.byKey(const Key('scan-button')));
       await tester.pumpAndSettle();
@@ -293,7 +293,7 @@ void main() {
         (WidgetTester tester) async {
       await tester.pumpWidget(createMealItemFormScreen(meal1, '123', true));
 
-      final MealItemForm formScreen = tester.widget(find.byType(MealItemForm));
+      final IngredientForm formScreen = tester.widget(find.byType(IngredientForm));
 
       await tester.tap(find.byKey(const Key('scan-button')));
       await tester.pumpAndSettle();

--- a/test/nutrition/nutritional_meal_item_form_test.dart
+++ b/test/nutrition/nutritional_meal_item_form_test.dart
@@ -213,7 +213,7 @@ void main() {
     testWidgets('confirm found ingredient dialog', (WidgetTester tester) async {
       await tester.pumpWidget(createMealItemFormScreen(meal1, '123', true));
 
-      final IngredientForm formScreen = tester.widget(find.byType(IngredientForm));
+      final IngredientFormState formState = tester.state(find.byType(IngredientForm));
 
       await tester.tap(find.byKey(const Key('scan-button')));
       await tester.pumpAndSettle();
@@ -223,7 +223,7 @@ void main() {
       await tester.tap(find.byKey(const Key('found-dialog-confirm-button')));
       await tester.pumpAndSettle();
 
-      expect(formScreen.ingredientIdController.text, '1');
+      expect(formState.ingredientIdController.text, '1');
     });
 
     testWidgets('close found ingredient dialog', (WidgetTester tester) async {
@@ -293,7 +293,7 @@ void main() {
         (WidgetTester tester) async {
       await tester.pumpWidget(createMealItemFormScreen(meal1, '123', true));
 
-      final IngredientForm formScreen = tester.widget(find.byType(IngredientForm));
+      final IngredientFormState formState = tester.state(find.byType(IngredientForm));
 
       await tester.tap(find.byKey(const Key('scan-button')));
       await tester.pumpAndSettle();
@@ -303,7 +303,7 @@ void main() {
       await tester.tap(find.byKey(const Key('found-dialog-confirm-button')));
       await tester.pumpAndSettle();
 
-      expect(formScreen.ingredientIdController.text, '1');
+      expect(formState.ingredientIdController.text, '1');
 
       await tester.enterText(find.byKey(const Key('field-weight')), '2');
       await tester.pumpAndSettle();
@@ -313,7 +313,7 @@ void main() {
       await tester.tap(find.byKey(const Key(SUBMIT_BUTTON_KEY_NAME)));
       await tester.pumpAndSettle();
 
-      expect(formScreen.mealItem.amount, 2);
+      expect(formState.mealItem.amount, 2);
 
       verify(mockNutrition.addMealItem(any, meal1));
     });


### PR DESCRIPTION
When:
1) logging an ingredient
2) modifying a meal and adding or an ingredient

the app already shows you a list of recently used ingredients, as well a form with the ingredient, and amount.

what this PR does:
1) on the list of recently used ingredients, show energy and macros of the ingredient on each tile
2) on the form, give a preview of what you're about to log/add to the meal, in terms of energy and macros. updates values in real time as you change the amount.

this should be handy because often i log an entry (save the form), and then check my diary and realize it isn't quite what i wanted. this is especially true when you are dealing with an ingredient on your plate that doesn't have an exact match in the database, and you have to use something "similar": it's nice to be able to see if the values make sense before you log it.

I also added a couple of cleanups and refactors to this PR. notably, the 2 mentioned forms were quite similar, so i merged them into 1 class.

future work: add a warning icon to the list tile in case the ingredient is missing a field that you need to to track against a goal (e.g. fiber)
