### PR TITLE
Weight entry QoL improvements

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -29,11 +29,12 @@
 - Bassam Mutairi - <https://github.com/mutairibassam>
 - Dieter Plaetinck - <https://github.com/Dieterbe>
 - Dennis van Peer - <https://github.com/Denpeer>
+- sizzlesloth - <https://github.com/sizzlesloth>
 
 ## Translators
 
 - Saudi Arabian
-  - Hanaa Allohibi <Gmail: programmerHanaa> 
+  - Hanaa Allohibi <Gmail: programmerHanaa>
 
 - German
 
@@ -66,7 +67,7 @@
 - Norwegian Bokmål
 
   - Allan Nordhøy <epost@anotheragency.no> (98)
-  
+
 - Japanese
 
   - Kosei TANAKA <wms784.app@gmail.com> (97)
@@ -76,5 +77,5 @@
   - Nenza Nurfirmansyah <nnurfirmansyah@gmail.com> (73)
 
 - Croatian
-  
+
   - Sandi Milohaic <sandi.milohanic@gmail.com>

--- a/lib/models/body_weight/weight_entry.dart
+++ b/lib/models/body_weight/weight_entry.dart
@@ -43,7 +43,7 @@ class WeightEntry {
   WeightEntry copyWith({int? id, int? weight, DateTime? date}) => WeightEntry(
         id: id,
         weight: weight ?? this.weight,
-        date: date ?? this.date,
+        date: date ?? DateTime.now(),
       );
 
   // Boilerplate

--- a/lib/widgets/weight/forms.dart
+++ b/lib/widgets/weight/forms.dart
@@ -110,8 +110,8 @@ class WeightForm extends StatelessWidget {
                     icon: const FaIcon(FontAwesomeIcons.minus),
                     onPressed: () {
                       try {
-                        final num newValue = num.parse(weightController.text) - 0.25;
-                        weightController.text = newValue.toString();
+                        final num newValue = num.parse(weightController.text) - 0.1;
+                        weightController.text = newValue.toStringAsFixed(1);
                       } on FormatException {}
                     },
                   ),
@@ -125,8 +125,8 @@ class WeightForm extends StatelessWidget {
                     icon: const FaIcon(FontAwesomeIcons.plus),
                     onPressed: () {
                       try {
-                        final num newValue = num.parse(weightController.text) + 0.25;
-                        weightController.text = newValue.toString();
+                        final num newValue = num.parse(weightController.text) + 0.1;
+                        weightController.text = newValue.toStringAsFixed(1);
                       } on FormatException {}
                     },
                   ),


### PR DESCRIPTION
## Description (Proposed Changes)

- Use current DateTime when copying WeightEntry instead of using previous weight.
- Increment buttons increment weight by 0.1 and round to one decimal place to prevent floating point accuracy (rounding) issues.

## Link to the issue : 

- Link : #628 

## Checklist

- [ ] Set a 100 character limit in your editor/IDE to avoid white space diffs in the PR
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Added yourself to AUTHORS.md
- [ ] Updated/added relevant documentation (doc comments with `///`).
- [ ] Added relevant reviewers.
