### PR TITLE
Fixing some hard-coded texts

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -30,6 +30,7 @@
 - Dieter Plaetinck - <https://github.com/Dieterbe>
 - Dennis van Peer - <https://github.com/Denpeer>
 - sizzlesloth - <https://github.com/sizzlesloth>
+- Xianglin Zeng - <https://github.com/FutureYL3>
 
 ## Translators
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -891,11 +891,26 @@
   "done": "Done",
   "overallChangeWeight": "Overall change",
   "@overallChangeWeight": {
-    "description": "Overall change in weight"
+    "description": "Overall change in weight, added for localization"
   },
   "goalTypeMeals": "From meals",
+  "@goalTypeMeals": {
+    "description": "added for localization of Class GoalType's filed meals"
+  },
   "goalTypeBasic": "Basic",
+  "@goalTypeBasic": {
+    "description": "added for localization of Class GoalType's filed basic"
+  },
   "goalTypeAdvanced": "Advanced",
+  "@goalTypeAdvanced": {
+    "description": "added for localization of Class GoalType's filed advanced"
+  },
   "indicatorRaw": "raw",
-  "indicatorAvg": "avg"
+  "@indicatorRaw": {
+    "description": "added for localization of Class Indicator's field text"
+  },
+  "indicatorAvg": "avg",
+  "@indicatorAvg": {
+    "description": "added for localization of Class Indicator's field text"
+  }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -888,5 +888,14 @@
   "@log": {
     "description": "Log a specific meal (imperative form)"
   },
-  "done": "Done"
+  "done": "Done",
+  "overallChangeWeight": "Overall change",
+  "@overallChangeWeight": {
+    "description": "Overall change in weight"
+  },
+  "goalTypeMeals": "From meals",
+  "goalTypeBasic": "Basic",
+  "goalTypeAdvanced": "Advanced",
+  "indicatorRaw": "raw",
+  "indicatorAvg": "avg"
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -252,7 +252,7 @@
   "@delete": {},
   "loadingText": "加载中...",
   "@loadingText": {
-    "description": "Text to show when entries are being loaded in the background: Loading..."
+    "description": "Text to show when entries are being loaded in the background: Loading..., changed from \"加载\" to \"加载中\""
   },
   "edit": "编辑",
   "@edit": {},
@@ -326,7 +326,7 @@
   },
   "weight": "体重",
   "@weight": {
-    "description": "The weight of a workout log or body weight entry"
+    "description": "The weight of a workout log or body weight entry, changed from \"重量\" to \"体重\"" 
   },
   "anErrorOccurred": "出错了!",
   "@anErrorOccurred": {},
@@ -350,7 +350,7 @@
   "@save": {},
   "name": "名称",
   "@name": {
-    "description": "Name for a workout or nutritional plan"
+    "description": "Name for a workout or nutritional plan, changed from \"名\" to \"名称\""
   },
   "description": "描述",
   "@description": {},
@@ -698,5 +698,11 @@
   "indicatorRaw": "原始值",
   "indicatorAvg": "平均值",
   "textPromptTitle": "准备就绪？",
-  "textPromptSubheading": "点击右下角按钮开始"
+  "@textPromptTitle": {
+    "description": "Title for the text prompt"
+  },
+  "textPromptSubheading": "点击右下角按钮开始",
+  "@textPromptSubheading": {
+    "description": "Subheading for the text prompt"
+  }
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -250,7 +250,7 @@
   },
   "delete": "删除",
   "@delete": {},
-  "loadingText": "加载...",
+  "loadingText": "加载中...",
   "@loadingText": {
     "description": "Text to show when entries are being loaded in the background: Loading..."
   },
@@ -324,7 +324,7 @@
   "@date": {
     "description": "The date of a workout log or body weight entry"
   },
-  "weight": "重量",
+  "weight": "体重",
   "@weight": {
     "description": "The weight of a workout log or body weight entry"
   },
@@ -348,7 +348,7 @@
   "@addMeal": {},
   "save": "保存",
   "@save": {},
-  "name": "名",
+  "name": "名称",
   "@name": {
     "description": "Name for a workout or nutritional plan"
   },
@@ -670,5 +670,33 @@
     }
   },
   "noMeasurementEntries": "您没有测量条目",
-  "@noMeasurementEntries": {}
+  "@noMeasurementEntries": {},
+  "overallChangeWeight": "总体变化",
+  "@overallChangeWeight": {
+    "description": "Overall change in weight"
+  },
+  "goalTypeMeals": "从饮食出发",
+  "goalTypeBasic": "基础",
+  "goalTypeAdvanced": "进阶",
+  "chartAllTimeTitle": "{name} 历史记录曲线",
+  "@chartAllTimeTitle": {
+    "description": "All-time chart of 'name' (e.g. 'weight', 'body fat' etc.)",
+    "type": "text",
+    "placeholders": {
+      "name": {}
+    }
+  },
+  "chartDuringPlanTitle": "{chartName} 在计划 \"{planName}\" 期间的改变曲线",
+  "@chartDuringPlanTitle": {
+    "description": "chart of 'chartName' (e.g. 'weight', 'body fat' etc.) logged during plan",
+    "type": "text",
+    "placeholders": {
+      "chartName": {},
+      "planName": {}
+    }
+  },
+  "indicatorRaw": "原始值",
+  "indicatorAvg": "平均值",
+  "textPromptTitle": "准备就绪？",
+  "textPromptSubheading": "点击右下角按钮开始"
 }

--- a/lib/widgets/measurements/charts.dart
+++ b/lib/widgets/measurements/charts.dart
@@ -37,7 +37,9 @@ class MeasurementOverallChangeWidget extends StatelessWidget {
             ? '-'
             : '';
 
-    return Text('${AppLocalizations.of(context).overallChangeWeight} $prefix ${delta.abs().toStringAsFixed(1)} $_unit');
+    // ignore: prefer_interpolation_to_compose_strings
+    return Text(AppLocalizations.of(context).overallChangeWeight +
+      '$prefix ${delta.abs().toStringAsFixed(1)} $_unit');
   }
 }
 

--- a/lib/widgets/measurements/charts.dart
+++ b/lib/widgets/measurements/charts.dart
@@ -37,7 +37,7 @@ class MeasurementOverallChangeWidget extends StatelessWidget {
             ? '-'
             : '';
 
-    return Text('overall change $prefix ${delta.abs().toStringAsFixed(1)} $_unit');
+    return Text('${AppLocalizations.of(context).overallChangeWeight} $prefix ${delta.abs().toStringAsFixed(1)} $_unit');
   }
 }
 

--- a/lib/widgets/measurements/helpers.dart
+++ b/lib/widgets/measurements/helpers.dart
@@ -77,8 +77,8 @@ List<Widget> getOverviewWidgetsSeries(
     Row(
       mainAxisAlignment: MainAxisAlignment.center,
       children: [
-        Indicator(color: Theme.of(context).colorScheme.primary, text: 'raw', isSquare: true),
-        Indicator(color: Theme.of(context).colorScheme.tertiary, text: 'avg', isSquare: true),
+        Indicator(color: Theme.of(context).colorScheme.primary, text: AppLocalizations.of(context).indicatorRaw, isSquare: true),
+        Indicator(color: Theme.of(context).colorScheme.tertiary, text: AppLocalizations.of(context).indicatorAvg, isSquare: true),
       ],
     ),
   ];

--- a/lib/widgets/nutrition/forms.dart
+++ b/lib/widgets/nutrition/forms.dart
@@ -484,6 +484,17 @@ enum GoalType {
 
   const GoalType(this.label);
   final String label;
+
+  String getI18nLabel(BuildContext context) {
+    switch (this) {
+      case GoalType.meals:
+        return AppLocalizations.of(context).goalTypeMeals;
+      case GoalType.basic:
+        return AppLocalizations.of(context).goalTypeBasic;
+      case GoalType.advanced:
+        return AppLocalizations.of(context).goalTypeAdvanced;
+    }
+  }
 }
 
 class PlanForm extends StatefulWidget {
@@ -572,7 +583,7 @@ class _PlanFormState extends State<PlanForm> {
                       .map(
                         (e) => DropdownMenuItem<GoalType>(
                           value: e,
-                          child: Text(e.label),
+                          child: Text(e.getI18nLabel(context)),
                         ),
                       )
                       .toList(),


### PR DESCRIPTION
## Description (Proposed Changes)

- improve expression of `loading`, `weight` and `name` from `加载`, `重量`, `名` to `加载中`, `体重`, `名称` to stick closer to Chinese expression habits
- fix hard-coded text `overall change` in widget `MeasurementOverallChangeWidget`, add relevent localization keys in `app_en.arb` and `app_zh.arb`
- fix hard-coded text in widget `Indicator`'s text field, also add relevent localization keys in `app_en.arb` and `app_zh.arb`
- fix hard-coded text in widget `PlanForm`'s `DropdownMenu` by adding a new method named `getI18nLabel` in widget `forms` to get localized labeltext
- add missing `textPromptTitle` and `textPromptSubheading` keys and theri values in `app_zh.arb`

some snapshots after fix:

![CleanShot 2024-11-05 at 00 09 13@2x](https://github.com/user-attachments/assets/9a99565d-af1b-40e8-9603-05973b7990cd)
![CleanShot 2024-11-05 at 00 10 18@2x](https://github.com/user-attachments/assets/318380e0-208e-4a46-9e42-1a9db1d334c8)
![CleanShot 2024-11-05 at 00 10 48@2x](https://github.com/user-attachments/assets/f14c1c7d-5eec-486e-8477-5dc2ec9c68c7)
![CleanShot 2024-11-05 at 00 11 02@2x](https://github.com/user-attachments/assets/f4958799-bb26-4209-b7a6-5a523475422d)

## Link to the issue : 

- Link : #284 

## Tests

- Since no bugs fixed or feature added, no test cases are added.  
- The localization made runs fine on my machine in Chinese environment.  
- If there needs to be some kind of tests, please let me know.

## Checklist

Please check that the PR fulfills all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] Set a 100 character limit in your editor/IDE to avoid white space diffs in the PR
- [x] Tests for the changes have been added (for bug fixes / features)
- Since no bug fixes, no test has been added. The fixed localization works fine on my machine.
- [x] Added yourself to AUTHORS.md
- [x] Updated/added relevant documentation (doc comments with `///`).
- add update logs to relevent descriptions in app_en.arb and app_zh.arb
- [x] Added relevant reviewers.
