### PR TITLE
fix: Handle timezone offset in meal logs entries

### DIFF
--- a/lib/helpers/json.dart
+++ b/lib/helpers/json.dart
@@ -19,6 +19,8 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
+final hourMinuteFormatter = NumberFormat('00');
+
 num stringToNum(String? e) {
   return e == null ? 0 : num.parse(e);
 }
@@ -50,7 +52,39 @@ String? dateToYYYYMMDD(DateTime? dateTime) {
   if (dateTime == null) {
     return null;
   }
-  return DateFormat('yyyy-MM-dd').format(dateTime);
+  return DateFormat('yyyy-MM-dd').format(dateTime.toUtc());
+}
+
+/*
+ * Converts a datetime to ISO8601 date format, with timezone offset
+ * https://github.com/dart-lang/sdk/issues/43391#issuecomment-1954335465
+ */
+String? dateToIso8601StringWithOffset(DateTime? dateTime) {
+  if (dateTime == null) {
+    return null;
+  }
+  final timeZoneOffset = dateTime.timeZoneOffset;
+  final sign = timeZoneOffset.isNegative ? '-' : '+';
+  final hours = hourMinuteFormatter.format(timeZoneOffset.inHours.abs());
+  final minutes = hourMinuteFormatter.format(timeZoneOffset.inMinutes.abs().remainder(60));
+  final offsetString = '$sign$hours:$minutes';
+  final formattedDate = dateTime.toIso8601String().split('.').first;
+  return '$formattedDate$offsetString';
+}
+
+/*
+ * Converts a date in ISO8601 format to a DateTime object, with local timezone.
+ */
+DateTime iso8601StringToLocalDateTime(String dateTime) {
+  final parsedDate = DateTime.parse(dateTime);
+  return parsedDate.toLocal();
+}
+
+DateTime? iso8601StringToLocalDateTimeNull(String? dateTime) {
+  if (dateTime == null) {
+    return null;
+  }
+  return iso8601StringToLocalDateTime(dateTime);
 }
 
 /*

--- a/lib/models/nutrition/log.dart
+++ b/lib/models/nutrition/log.dart
@@ -36,7 +36,8 @@ class Log {
   @JsonKey(required: true, name: 'plan')
   int planId;
 
-  @JsonKey(required: true)
+  @JsonKey(
+      required: true, toJson: dateToIso8601StringWithOffset, fromJson: iso8601StringToLocalDateTime)
   late DateTime datetime;
 
   String? comment;

--- a/lib/models/nutrition/log.g.dart
+++ b/lib/models/nutrition/log.g.dart
@@ -18,7 +18,7 @@ Log _$LogFromJson(Map<String, dynamic> json) {
     weightUnitId: (json['weight_unit'] as num?)?.toInt(),
     amount: stringToNum(json['amount'] as String?),
     planId: (json['plan'] as num).toInt(),
-    datetime: DateTime.parse(json['datetime'] as String),
+    datetime: iso8601StringToLocalDateTime(json['datetime'] as String),
     comment: json['comment'] as String?,
   );
 }
@@ -27,7 +27,7 @@ Map<String, dynamic> _$LogToJson(Log instance) => <String, dynamic>{
       'id': instance.id,
       'meal': instance.mealId,
       'plan': instance.planId,
-      'datetime': instance.datetime.toIso8601String(),
+      'datetime': dateToIso8601StringWithOffset(instance.datetime),
       'comment': instance.comment,
       'ingredient': instance.ingredientId,
       'weight_unit': instance.weightUnitId,

--- a/test/helpers/json_test.dart
+++ b/test/helpers/json_test.dart
@@ -59,5 +59,55 @@ void main() {
         expect(timeToString(time), '12:34');
       });
     });
+
+    group('dateToIso8601StringWithOffset', () {
+      test('should return null for null input', () {
+        expect(dateToIso8601StringWithOffset(null), isNull);
+      });
+
+      test('should format DateTime with positive offset', () {
+        final dateTime = DateTime(2023, 6, 15, 14, 30).toLocal();
+        final result = dateToIso8601StringWithOffset(dateTime);
+
+        // Extract the date part and offset part
+        final datePart = result!.substring(0, 19); // YYYY-MM-DDTHH:mm:ss
+        final offsetPart = result.substring(19); // +HH:mm or -HH:mm
+
+        expect(datePart, matches(RegExp(r'^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$')));
+        expect(offsetPart, matches(RegExp(r'^[+-]\d{2}:\d{2}$')));
+      });
+    });
+
+    group('iso8601StringToLocalDateTime', () {
+      test('should parse UTC ISO string correctly', () {
+        const input = '2023-06-15T14:30:00Z';
+        final result = iso8601StringToLocalDateTime(input);
+
+        expect(result, isA<DateTime>());
+        expect(result.isUtc, isFalse); // Should be converted to local time
+      });
+
+      test('should parse ISO string with offset correctly', () {
+        const input = '2023-06-15T14:30:00+02:00';
+        final result = iso8601StringToLocalDateTime(input);
+
+        expect(result, isA<DateTime>());
+        expect(result.isUtc, isFalse);
+      });
+    });
+
+    group('iso8601StringToLocalDateTimeNull', () {
+      test('should return null for null input', () {
+        expect(iso8601StringToLocalDateTimeNull(null), isNull);
+      });
+
+      test('should parse valid ISO string', () {
+        const input = '2023-06-15T14:30:00Z';
+        final result = iso8601StringToLocalDateTimeNull(input);
+
+        expect(result, isA<DateTime>());
+        expect(result!.isUtc, isFalse);
+      });
+    });
   });
 }


### PR DESCRIPTION
# Proposed Changes

Dart's `DateTime` parses dates as being in the local timezone by default, and doesn't add the timezone to strings by default. This adds some custom formatting for the JSON serialization, so that the Flutter app understands dates from the wger server having a tz suffix like `+02:00`.

## Related Issue(s)

See #576