### PR TITLE
timer code is now updated and uses a better approach

### DIFF
--- a/lib/widgets/routines/gym_mode/timer.dart
+++ b/lib/widgets/routines/gym_mode/timer.dart
@@ -49,7 +49,8 @@ class _TimerWidgetState extends State<TimerWidget> {
     super.initState();
     _startTime = DateTime.now();
 
-    _uiTimer = Timer.periodic(Duration(seconds: 1), (_) {
+    _uiTimer = Timer.periodic(const Duration(seconds: 1), (_) {
+      // ignore: no-empty-block, avoid-empty-setstate
       if (mounted) setState(() {});
     });
   }
@@ -64,8 +65,7 @@ class _TimerWidgetState extends State<TimerWidget> {
   Widget build(BuildContext context) {
     final elapsed = DateTime.now().difference(_startTime).inSeconds;
     final displaySeconds = elapsed > _maxSeconds ? _maxSeconds : elapsed;
-    final displayTime = DateTime(2000, 1, 1, 0, 0, 0)
-        .add(Duration(seconds: displaySeconds));
+    final displayTime = DateTime(2000, 1, 1, 0, 0, 0).add(Duration(seconds: displaySeconds));
 
     return Column(
       children: [
@@ -78,10 +78,7 @@ class _TimerWidgetState extends State<TimerWidget> {
           child: Center(
             child: Text(
               DateFormat('m:ss').format(displayTime),
-              style: Theme.of(context)
-                  .textTheme
-                  .displayLarge!
-                  .copyWith(color: wgerPrimaryColor),
+              style: Theme.of(context).textTheme.displayLarge!.copyWith(color: wgerPrimaryColor),
             ),
           ),
         ),
@@ -117,7 +114,8 @@ class _TimerCountdownWidgetState extends State<TimerCountdownWidget> {
     super.initState();
     _endTime = DateTime.now().add(Duration(seconds: widget._seconds));
 
-    _uiTimer = Timer.periodic(Duration(seconds: 1), (_) {
+    _uiTimer = Timer.periodic(const Duration(seconds: 1), (_) {
+      // ignore: no-empty-block, avoid-empty-setstate
       if (mounted) setState(() {});
     });
   }
@@ -132,8 +130,7 @@ class _TimerCountdownWidgetState extends State<TimerCountdownWidget> {
   Widget build(BuildContext context) {
     final remaining = _endTime.difference(DateTime.now());
     final remainingSeconds = remaining.inSeconds <= 0 ? 0 : remaining.inSeconds;
-    final displayTime = DateTime(2000, 1, 1, 0, 0, 0)
-        .add(Duration(seconds: remainingSeconds));
+    final displayTime = DateTime(2000, 1, 1, 0, 0, 0).add(Duration(seconds: remainingSeconds));
 
     return Column(
       children: [
@@ -146,10 +143,7 @@ class _TimerCountdownWidgetState extends State<TimerCountdownWidget> {
           child: Center(
             child: Text(
               DateFormat('m:ss').format(displayTime),
-              style: Theme.of(context)
-                  .textTheme
-                  .displayLarge!
-                  .copyWith(color: wgerPrimaryColor),
+              style: Theme.of(context).textTheme.displayLarge!.copyWith(color: wgerPrimaryColor),
             ),
           ),
         ),

--- a/lib/widgets/routines/gym_mode/timer.dart
+++ b/lib/widgets/routines/gym_mode/timer.dart
@@ -40,42 +40,33 @@ class TimerWidget extends StatefulWidget {
 }
 
 class _TimerWidgetState extends State<TimerWidget> {
-  // See https://stackoverflow.com/questions/54610121/flutter-countdown-timer
-
-  Timer? _timer;
-  int _seconds = 1;
+  late DateTime _startTime;
   final _maxSeconds = 600;
-  DateTime today = DateTime(2000, 1, 1, 0, 0, 0);
+  late Timer _uiTimer;
 
-  void startTimer() {
-    setState(() => _seconds = 0);
+  @override
+  void initState() {
+    super.initState();
+    _startTime = DateTime.now();
 
-    _timer?.cancel();
-
-    const oneSecond = Duration(seconds: 1);
-    _timer = Timer.periodic(oneSecond, (Timer timer) {
-      if (_seconds == _maxSeconds) {
-        setState(() => timer.cancel());
-      } else {
-        setState(() => _seconds++);
-      }
+    _uiTimer = Timer.periodic(Duration(seconds: 1), (_) {
+      if (mounted) setState(() {});
     });
   }
 
   @override
   void dispose() {
-    _timer?.cancel();
+    _uiTimer.cancel();
     super.dispose();
   }
 
   @override
-  void initState() {
-    super.initState();
-    startTimer();
-  }
-
-  @override
   Widget build(BuildContext context) {
+    final elapsed = DateTime.now().difference(_startTime).inSeconds;
+    final displaySeconds = elapsed > _maxSeconds ? _maxSeconds : elapsed;
+    final displayTime = DateTime(2000, 1, 1, 0, 0, 0)
+        .add(Duration(seconds: displaySeconds));
+
     return Column(
       children: [
         NavigationHeader(
@@ -86,8 +77,11 @@ class _TimerWidgetState extends State<TimerWidget> {
         Expanded(
           child: Center(
             child: Text(
-              DateFormat('m:ss').format(today.add(Duration(seconds: _seconds))),
-              style: Theme.of(context).textTheme.displayLarge!.copyWith(color: wgerPrimaryColor),
+              DateFormat('m:ss').format(displayTime),
+              style: Theme.of(context)
+                  .textTheme
+                  .displayLarge!
+                  .copyWith(color: wgerPrimaryColor),
             ),
           ),
         ),
@@ -115,40 +109,32 @@ class TimerCountdownWidget extends StatefulWidget {
 }
 
 class _TimerCountdownWidgetState extends State<TimerCountdownWidget> {
-  // See https://stackoverflow.com/questions/54610121/flutter-countdown-timer
+  late DateTime _endTime;
+  late Timer _uiTimer;
 
-  Timer? _timer;
-  late int _seconds;
-  DateTime today = DateTime(2000, 1, 1, 0, 0, 0);
+  @override
+  void initState() {
+    super.initState();
+    _endTime = DateTime.now().add(Duration(seconds: widget._seconds));
 
-  void startTimer() {
-    _timer?.cancel();
-
-    const oneSecond = Duration(seconds: 1);
-    _timer = Timer.periodic(oneSecond, (Timer timer) {
-      if (_seconds == 0) {
-        setState(() => timer.cancel());
-      } else {
-        setState(() => _seconds--);
-      }
+    _uiTimer = Timer.periodic(Duration(seconds: 1), (_) {
+      if (mounted) setState(() {});
     });
   }
 
   @override
   void dispose() {
-    _timer?.cancel();
+    _uiTimer.cancel();
     super.dispose();
   }
 
   @override
-  void initState() {
-    super.initState();
-    _seconds = widget._seconds;
-    startTimer();
-  }
-
-  @override
   Widget build(BuildContext context) {
+    final remaining = _endTime.difference(DateTime.now());
+    final remainingSeconds = remaining.inSeconds <= 0 ? 0 : remaining.inSeconds;
+    final displayTime = DateTime(2000, 1, 1, 0, 0, 0)
+        .add(Duration(seconds: remainingSeconds));
+
     return Column(
       children: [
         NavigationHeader(
@@ -159,8 +145,11 @@ class _TimerCountdownWidgetState extends State<TimerCountdownWidget> {
         Expanded(
           child: Center(
             child: Text(
-              DateFormat('m:ss').format(today.add(Duration(seconds: _seconds))),
-              style: Theme.of(context).textTheme.displayLarge!.copyWith(color: wgerPrimaryColor),
+              DateFormat('m:ss').format(displayTime),
+              style: Theme.of(context)
+                  .textTheme
+                  .displayLarge!
+                  .copyWith(color: wgerPrimaryColor),
             ),
           ),
         ),


### PR DESCRIPTION
# Proposed Changes

The timer issue faced could be due to how the OS handles background processes and timers. The issue could be addressed with a better solution which uses  DateTime start time and calculate the elapsed duration using DateTime.now().difference(startTime). This way, the timer would accurately update the time and the OS issue might be solved too.

## Related Issue(s)

Closes issue #784 