### PR TITLE
Fix/end date picker validation

### DIFF
--- a/lib/widgets/routines/forms/routine.dart
+++ b/lib/widgets/routines/forms/routine.dart
@@ -10,6 +10,8 @@ import 'package:wger/providers/routines.dart';
 import 'package:wger/screens/routine_edit_screen.dart';
 import 'package:wger/widgets/core/progress_indicator.dart';
 
+/// A form widget for creating and editing workout routines.
+/// Handles validation and user input for routine details, including start and end dates.
 class RoutineForm extends StatefulWidget {
   final Routine _routine;
   final bool useListView;
@@ -152,6 +154,9 @@ class _RoutineFormState extends State<RoutineForm> {
       TextFormField(
         key: const Key('field-end-date'),
         readOnly: true,
+        /// Opens a date picker for selecting the routine's end date.
+        /// Ensures the end date is always after the start date and allows selection up to 10 years in the future.
+        /// The initial date shown is the current end date if valid, otherwise the minimum allowed end date.
         decoration: const InputDecoration(
           labelText: 'End date',
           suffixIcon: Icon(


### PR DESCRIPTION
…rt date

# Proposed Changes
-Fix end date picker so that the initial date is always after the start date and never before it.
-Prevents assertion errors in the date picker dialog when the end date is before or equal to the start date.
-Allows users to select end dates up to 10 years in the future.

## Related Issue(s)

If applicable, please link to any related issues (`Closes #123`,
`Closes wger-project/other-repo#123`, `See also #123`, etc.)

## Please check that the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Set a 100 character limit in your editor/IDE to avoid white space diffs in the PR
  (run `dart format .`)
- [x] Updated/added relevant documentation (doc ccomments with `///`).
- [ ] Added relevant reviewers.
