### PR TITLE
fix: allow both http and https for server URL, default to https if mi…

### DIFF
--- a/lib/screens/auth_screen.dart
+++ b/lib/screens/auth_screen.dart
@@ -38,6 +38,17 @@ enum AuthMode {
   Login,
 }
 
+/// Ensures the server URL has a protocol. Defaults to https:// if none is specified.
+String normalizeServerUrl(String url) {
+  if (url.isEmpty) return url;
+  url = url.trim();
+  if (url.startsWith('http://') || url.startsWith('https://')) {
+    return url;
+  }
+  // Default to https if no protocol is specified
+  return 'https://$url';
+}
+
 class AuthScreen extends StatelessWidget {
   const AuthScreen();
 
@@ -327,7 +338,7 @@ class _AuthCardState extends State<AuthCard> {
                         if (value!.lastIndexOf('/') == (value.length - 1)) {
                           value = value.substring(0, value.lastIndexOf('/'));
                         }
-                        _authData['serverUrl'] = value;
+                        _authData['serverUrl'] = normalizeServerUrl(value);
                       },
                     ),
                   ),


### PR DESCRIPTION
# Proposed Changes

- Allow both `http` and `https` protocols for the server URL.
- If the user does not specify a protocol, default to `https://`.
- Prevents connection issues for users with self-hosted HTTP servers or strict HTTPS-only servers.

## Related Issue(s)

Closes #860

## Please check that the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Set a 100 character limit in your editor/IDE to avoid white space diffs in the PR (run `dart format .`)
- [x] Updated/added relevant documentation (doc comments with `///`).
- [ ] Added relevant reviewers.