### PR TITLE
changed calendar settings to allow to choose future days upto 112 days.

### DIFF
--- a/lib/widgets/dashboard/calendar.dart
+++ b/lib/widgets/dashboard/calendar.dart
@@ -225,7 +225,7 @@ class _DashboardCalendarWidgetState extends State<DashboardCalendarWidget>
           TableCalendar<Event>(
             locale: Localizations.localeOf(context).languageCode,
             firstDay: DateTime.now().subtract(const Duration(days: 1000)),
-            lastDay: DateTime.now().add(const Duration(days: 112)),
+            lastDay: DateTime.now().add(const Duration(days: 365)),
             focusedDay: _focusedDay,
             selectedDayPredicate: (day) => isSameDay(_selectedDay, day),
             rangeStartDay: _rangeStart,

--- a/lib/widgets/dashboard/calendar.dart
+++ b/lib/widgets/dashboard/calendar.dart
@@ -225,7 +225,7 @@ class _DashboardCalendarWidgetState extends State<DashboardCalendarWidget>
           TableCalendar<Event>(
             locale: Localizations.localeOf(context).languageCode,
             firstDay: DateTime.now().subtract(const Duration(days: 1000)),
-            lastDay: DateTime.now(),
+            lastDay: DateTime.now().add(const Duration(days: 112)),
             focusedDay: _focusedDay,
             selectedDayPredicate: (day) => isSameDay(_selectedDay, day),
             rangeStartDay: _rangeStart,

--- a/lib/widgets/routines/forms/routine.dart
+++ b/lib/widgets/routines/forms/routine.dart
@@ -163,7 +163,7 @@ class _RoutineFormState extends State<RoutineForm> {
             context: context,
             initialDate: endDate,
             firstDate: DateTime(DateTime.now().year - 10),
-            lastDate: DateTime.now().add(const Duration(days: 112)),
+            lastDate: DateTime.now().add(const Duration(days: 365)),
           );
 
           if (picked == null) {

--- a/lib/widgets/routines/forms/routine.dart
+++ b/lib/widgets/routines/forms/routine.dart
@@ -163,7 +163,7 @@ class _RoutineFormState extends State<RoutineForm> {
             context: context,
             initialDate: endDate,
             firstDate: DateTime(DateTime.now().year - 10),
-            lastDate: DateTime.now(),
+            lastDate: DateTime.now().add(const Duration(days: 112)),
           );
 
           if (picked == null) {


### PR DESCRIPTION
# Proposed Changes

- Allow users to choose date upto 112 days as end date in date picker for routines.
- see Issue #872 
## Related Issue(s)

If applicable, please link to any related issues Closes #872 

## Please check that the PR fulfills these requirements

- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Set a 100 character limit in your editor/IDE to avoid white space diffs in the PR
  (run `dart format .`)
- [ ] Updated/added relevant documentation (doc comments with `///`).
- [X] Added relevant reviewers. @rolandgeider @Dieterbe 
<img width="1920" height="1020" alt="Screenshot 2025-07-23 210955" src="https://github.com/user-attachments/assets/34104274-d915-43b1-900c-fa5cf53f3eb4" />