### PR TITLE
Improve exercise cache control

### DIFF
--- a/lib/providers/exercises.dart
+++ b/lib/providers/exercises.dart
@@ -47,6 +47,7 @@ class ExercisesProvider with ChangeNotifier {
   static const EXERCISE_CACHE_DAYS = 7;
   static const CACHE_VERSION = 4;
 
+  static const exerciseUrlPath = 'exercise';
   static const exerciseInfoUrlPath = 'exerciseinfo';
   static const exerciseSearchPath = 'exercise/search';
 
@@ -274,6 +275,18 @@ class ExercisesProvider with ChangeNotifier {
     }
   }
 
+  Future<void> fetchAndSetAllExercises() async {
+    _logger.info('Loading all exercises from API');
+    final exerciseData = await baseProvider.fetchPaginated(
+      baseProvider.makeUrl(exerciseUrlPath, query: {'limit': API_MAX_PAGE_SIZE}),
+    );
+    final exerciseIds = exerciseData.map<int>((e) => e['id'] as int).toSet();
+
+    for (final exerciseId in exerciseIds) {
+      await handleUpdateExerciseFromApi(database, exerciseId);
+    }
+  }
+
   /// Returns the exercise with the given ID
   ///
   /// If the exercise is not known locally, it is fetched from the server.
@@ -291,6 +304,7 @@ class ExercisesProvider with ChangeNotifier {
 
       return exercise;
     } on NoSuchEntryException {
+      // _logger.finer('Exercise not found locally, fetching from the API');
       return handleUpdateExerciseFromApi(database, exerciseId);
     }
   }

--- a/lib/providers/routines.dart
+++ b/lib/providers/routines.dart
@@ -153,13 +153,14 @@ class RoutinesProvider with ChangeNotifier {
   /// Fetches and sets all workout plans fully, i.e. with all corresponding child
   /// attributes
   Future<void> fetchAndSetAllRoutinesFull() async {
-    final data = await baseProvider.fetch(
+    _logger.fine('Fetching all routines fully');
+    final data = await baseProvider.fetchPaginated(
       baseProvider.makeUrl(
         _routinesUrlPath,
         query: {'ordering': '-creation_date', 'limit': API_MAX_PAGE_SIZE, 'is_template': 'false'},
       ),
     );
-    for (final entry in data['results']) {
+    for (final entry in data) {
       await fetchAndSetRoutineFull(entry['id']);
     }
 
@@ -169,6 +170,7 @@ class RoutinesProvider with ChangeNotifier {
   /// Fetches all routines sparsely, i.e. only with the data on the object itself
   /// and no child attributes
   Future<void> fetchAndSetAllRoutinesSparse() async {
+    _logger.fine('Fetching all routines sparsely');
     final data = await baseProvider.fetch(
       baseProvider.makeUrl(
         _routinesUrlPath,

--- a/lib/screens/home_tabs_screen.dart
+++ b/lib/screens/home_tabs_screen.dart
@@ -86,6 +86,7 @@ class _HomeTabsScreenState extends State<HomeTabsScreen> with SingleTickerProvid
       final measurementProvider = context.read<MeasurementProvider>();
       final userProvider = context.read<UserProvider>();
 
+      //
       // Base data
       widget._logger.info('Loading base data');
       await Future.wait([
@@ -95,7 +96,18 @@ class _HomeTabsScreenState extends State<HomeTabsScreen> with SingleTickerProvid
         nutritionPlansProvider.fetchIngredientsFromCache(),
         exercisesProvider.fetchAndSetInitialData(),
       ]);
+      exercisesProvider.fetchAndSetAllExercises();
 
+      // Workaround for https://github.com/wger-project/flutter/issues/901
+      // It seems that it can happen that sometimes the units were not loaded properly
+      // so now we check and try again if necessary. We might need a better general
+      // solution since this could potentially happen with other data as well.
+      if (routinesProvider.repetitionUnits.isEmpty || routinesProvider.weightUnits.isEmpty) {
+        widget._logger.info('Routine units are empty, fetching again');
+        await routinesProvider.fetchAndSetUnits();
+      }
+
+      //
       // Plans, weight and gallery
       widget._logger.info('Loading routines, weight, measurements and gallery');
       await Future.wait([
@@ -107,6 +119,7 @@ class _HomeTabsScreenState extends State<HomeTabsScreen> with SingleTickerProvid
         measurementProvider.fetchAndSetAllCategoriesAndEntries(),
       ]);
 
+      //
       // Current nutritional plan
       widget._logger.info('Loading current nutritional plan');
       if (nutritionPlansProvider.currentPlan != null) {
@@ -114,6 +127,7 @@ class _HomeTabsScreenState extends State<HomeTabsScreen> with SingleTickerProvid
         await nutritionPlansProvider.fetchAndSetPlanFull(plan.id!);
       }
 
+      //
       // Current routine
       widget._logger.info('Loading current routine');
       if (routinesProvider.currentRoutine != null) {

--- a/lib/widgets/core/settings.dart
+++ b/lib/widgets/core/settings.dart
@@ -20,10 +20,10 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:wger/l10n/generated/app_localizations.dart';
-import 'package:wger/providers/exercises.dart';
 import 'package:wger/providers/nutrition.dart';
 import 'package:wger/providers/user.dart';
 import 'package:wger/screens/configure_plates_screen.dart';
+import 'package:wger/widgets/core/settings/exercise_cache.dart';
 
 class SettingsPage extends StatelessWidget {
   static String routeName = '/SettingsPage';
@@ -33,7 +33,6 @@ class SettingsPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final i18n = AppLocalizations.of(context);
-    final exerciseProvider = Provider.of<ExercisesProvider>(context, listen: false);
     final nutritionProvider = Provider.of<NutritionPlansProvider>(context, listen: false);
     final userProvider = Provider.of<UserProvider>(context);
 
@@ -47,24 +46,7 @@ class SettingsPage extends StatelessWidget {
               style: Theme.of(context).textTheme.headlineSmall,
             ),
           ),
-          ListTile(
-            title: Text(i18n.settingsExerciseCacheDescription),
-            trailing: IconButton(
-              key: const ValueKey('cacheIconExercises'),
-              icon: const Icon(Icons.delete),
-              onPressed: () async {
-                await exerciseProvider.clearAllCachesAndPrefs();
-
-                if (context.mounted) {
-                  final snackBar = SnackBar(
-                    content: Text(i18n.settingsCacheDeletedSnackbar),
-                  );
-
-                  ScaffoldMessenger.of(context).showSnackBar(snackBar);
-                }
-              },
-            ),
-          ),
+          const SettingsExerciseCache(),
           ListTile(
             title: Text(i18n.settingsIngredientCacheDescription),
             trailing: IconButton(
@@ -81,6 +63,12 @@ class SettingsPage extends StatelessWidget {
                   ScaffoldMessenger.of(context).showSnackBar(snackBar);
                 }
               },
+            ),
+          ),
+          ListTile(
+            title: Text(
+              i18n.others,
+              style: Theme.of(context).textTheme.headlineSmall,
             ),
           ),
           ListTile(

--- a/lib/widgets/core/settings/exercise_cache.dart
+++ b/lib/widgets/core/settings/exercise_cache.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:wger/l10n/generated/app_localizations.dart';
+import 'package:wger/providers/exercises.dart';
+
+class SettingsExerciseCache extends StatefulWidget {
+  const SettingsExerciseCache({super.key});
+
+  @override
+  State<SettingsExerciseCache> createState() => _SettingsExerciseCacheState();
+}
+
+class _SettingsExerciseCacheState extends State<SettingsExerciseCache> {
+  bool _isRefreshLoading = false;
+  String _subtitle = '';
+
+  @override
+  Widget build(BuildContext context) {
+    final exerciseProvider = Provider.of<ExercisesProvider>(context, listen: false);
+    final i18n = AppLocalizations.of(context);
+
+    return ListTile(
+      enabled: !_isRefreshLoading,
+      title: Text(i18n.settingsExerciseCacheDescription),
+      subtitle: _subtitle.isNotEmpty ? Text(_subtitle) : null,
+      trailing: Row(mainAxisSize: MainAxisSize.min, children: [
+        IconButton(
+          key: const ValueKey('cacheIconExercisesRefresh'),
+          icon: _isRefreshLoading
+              ? const SizedBox(
+                  width: 24,
+                  height: 24,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Icon(Icons.refresh),
+          onPressed: _isRefreshLoading
+              ? null
+              : () async {
+                  setState(() => _isRefreshLoading = true);
+
+                  // Note: status messages are currently left in English on purpose
+                  try {
+                    setState(() => _subtitle = 'Clearing cache...');
+                    await exerciseProvider.clearAllCachesAndPrefs();
+
+                    if (mounted) {
+                      setState(() => _subtitle = 'Loading languages and units...');
+                    }
+                    await exerciseProvider.fetchAndSetInitialData();
+
+                    if (mounted) {
+                      setState(() => _subtitle = 'Loading all exercises from server...');
+                    }
+                    await exerciseProvider.fetchAndSetAllExercises();
+
+                    if (mounted) {
+                      setState(() => _subtitle = '');
+                    }
+                  } finally {
+                    if (mounted) {
+                      setState(() => _isRefreshLoading = false);
+                    }
+                    if (context.mounted) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(content: Text(i18n.success)),
+                      );
+                    }
+                  }
+                },
+        ),
+        IconButton(
+          key: const ValueKey('cacheIconExercisesDelete'),
+          icon: const Icon(Icons.delete),
+          onPressed: () async {
+            await exerciseProvider.clearAllCachesAndPrefs();
+
+            if (context.mounted) {
+              final snackBar = SnackBar(
+                content: Text(i18n.settingsCacheDeletedSnackbar),
+              );
+
+              ScaffoldMessenger.of(context).showSnackBar(snackBar);
+            }
+          },
+        )
+      ]),
+    );
+  }
+}

--- a/test/core/settings_test.dart
+++ b/test/core/settings_test.dart
@@ -39,7 +39,7 @@ import 'settings_test.mocks.dart';
   WgerBaseProvider,
   SharedPreferencesAsync,
 ])
-void main() async {
+void main() {
   final mockExerciseProvider = MockExercisesProvider();
   final mockNutritionProvider = MockNutritionPlansProvider();
   final mockSharedPreferences = MockSharedPreferencesAsync();
@@ -68,10 +68,20 @@ void main() async {
   group('Cache', () {
     testWidgets('Test resetting the exercise cache', (WidgetTester tester) async {
       await tester.pumpWidget(createSettingsScreen());
-      await tester.tap(find.byKey(const ValueKey('cacheIconExercises')));
+      await tester.tap(find.byKey(const ValueKey('cacheIconExercisesDelete')));
       await tester.pumpAndSettle();
 
       verify(mockExerciseProvider.clearAllCachesAndPrefs());
+    });
+
+    testWidgets('Test refreshing the exercise cache', (WidgetTester tester) async {
+      await tester.pumpWidget(createSettingsScreen());
+      await tester.tap(find.byKey(const ValueKey('cacheIconExercisesRefresh')));
+      await tester.pumpAndSettle();
+
+      verify(mockExerciseProvider.clearAllCachesAndPrefs());
+      verify(mockExerciseProvider.fetchAndSetInitialData());
+      verify(mockExerciseProvider.fetchAndSetAllExercises());
     });
 
     testWidgets('Test resetting the ingredient cache', (WidgetTester tester) async {

--- a/test/core/settings_test.mocks.dart
+++ b/test/core/settings_test.mocks.dart
@@ -491,6 +491,16 @@ class MockExercisesProvider extends _i1.Mock implements _i17.ExercisesProvider {
       ) as _i18.Future<void>);
 
   @override
+  _i18.Future<void> fetchAndSetAllExercises() => (super.noSuchMethod(
+        Invocation.method(
+          #fetchAndSetAllExercises,
+          [],
+        ),
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
+
+  @override
   _i18.Future<_i4.Exercise?> fetchAndSetExercise(int? exerciseId) => (super.noSuchMethod(
         Invocation.method(
           #fetchAndSetExercise,

--- a/test/exercises/contribute_exercise_test.mocks.dart
+++ b/test/exercises/contribute_exercise_test.mocks.dart
@@ -946,6 +946,16 @@ class MockExercisesProvider extends _i1.Mock implements _i20.ExercisesProvider {
       ) as _i15.Future<void>);
 
   @override
+  _i15.Future<void> fetchAndSetAllExercises() => (super.noSuchMethod(
+        Invocation.method(
+          #fetchAndSetAllExercises,
+          [],
+        ),
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
+
+  @override
   _i15.Future<_i3.Exercise?> fetchAndSetExercise(int? exerciseId) => (super.noSuchMethod(
         Invocation.method(
           #fetchAndSetExercise,

--- a/test/exercises/exercises_detail_widget_test.mocks.dart
+++ b/test/exercises/exercises_detail_widget_test.mocks.dart
@@ -378,6 +378,16 @@ class MockExercisesProvider extends _i1.Mock implements _i9.ExercisesProvider {
       ) as _i10.Future<void>);
 
   @override
+  _i10.Future<void> fetchAndSetAllExercises() => (super.noSuchMethod(
+        Invocation.method(
+          #fetchAndSetAllExercises,
+          [],
+        ),
+        returnValue: _i10.Future<void>.value(),
+        returnValueForMissingStub: _i10.Future<void>.value(),
+      ) as _i10.Future<void>);
+
+  @override
   _i10.Future<_i4.Exercise?> fetchAndSetExercise(int? exerciseId) => (super.noSuchMethod(
         Invocation.method(
           #fetchAndSetExercise,

--- a/test/routine/gym_mode_screen_test.mocks.dart
+++ b/test/routine/gym_mode_screen_test.mocks.dart
@@ -581,6 +581,16 @@ class MockExercisesProvider extends _i1.Mock implements _i12.ExercisesProvider {
       ) as _i11.Future<void>);
 
   @override
+  _i11.Future<void> fetchAndSetAllExercises() => (super.noSuchMethod(
+        Invocation.method(
+          #fetchAndSetAllExercises,
+          [],
+        ),
+        returnValue: _i11.Future<void>.value(),
+        returnValueForMissingStub: _i11.Future<void>.value(),
+      ) as _i11.Future<void>);
+
+  @override
   _i11.Future<_i6.Exercise?> fetchAndSetExercise(int? exerciseId) => (super.noSuchMethod(
         Invocation.method(
           #fetchAndSetExercise,

--- a/test/routine/routines_provider_test.mocks.dart
+++ b/test/routine/routines_provider_test.mocks.dart
@@ -581,6 +581,16 @@ class MockExercisesProvider extends _i1.Mock implements _i12.ExercisesProvider {
       ) as _i11.Future<void>);
 
   @override
+  _i11.Future<void> fetchAndSetAllExercises() => (super.noSuchMethod(
+        Invocation.method(
+          #fetchAndSetAllExercises,
+          [],
+        ),
+        returnValue: _i11.Future<void>.value(),
+        returnValueForMissingStub: _i11.Future<void>.value(),
+      ) as _i11.Future<void>);
+
+  @override
   _i11.Future<_i6.Exercise?> fetchAndSetExercise(int? exerciseId) => (super.noSuchMethod(
         Invocation.method(
           #fetchAndSetExercise,


### PR DESCRIPTION
# Proposed Changes

Allows users to manually reload the exercise data cache in the settings page, loading all available exercises from the server. (this now also happens on first run). We also check if unit data was properly loaded and try again (see #901), even if this should not really happen.

## Related Issue(s)

Closes #901 