### PR TITLE
Don't hammer the server with search requests

### DIFF
--- a/lib/widgets/exercises/autocompleter.dart
+++ b/lib/widgets/exercises/autocompleter.dart
@@ -30,6 +30,7 @@ class _ExerciseAutocompleterState extends State<ExerciseAutocompleter> {
       children: [
         TypeAheadField<Exercise>(
           key: const Key('field-typeahead'),
+          debounceDuration: const Duration(milliseconds: 500),
           decorationBuilder: (context, child) {
             return Material(
               type: MaterialType.card,

--- a/lib/widgets/nutrition/widgets.dart
+++ b/lib/widgets/nutrition/widgets.dart
@@ -113,6 +113,7 @@ class _IngredientTypeaheadState extends State<IngredientTypeahead> {
       children: [
         TypeAheadField<IngredientApiSearchEntry>(
           controller: widget._ingredientController,
+          debounceDuration: const Duration(milliseconds: 500),
           builder: (context, controller, focusNode) {
             return TextFormField(
               controller: controller,
@@ -123,11 +124,6 @@ class _IngredientTypeaheadState extends State<IngredientTypeahead> {
                   return AppLocalizations.of(context).selectIngredient;
                 }
                 return null;
-              },
-              onChanged: (value) {
-                widget.updateSearchQuery(value);
-                // unselect to start a new search
-                widget.unSelectIngredient();
               },
               decoration: InputDecoration(
                 prefixIcon: const Icon(Icons.search),
@@ -141,6 +137,10 @@ class _IngredientTypeaheadState extends State<IngredientTypeahead> {
             if (pattern == '' || widget._ingredientIdController.text.isNotEmpty) {
               return null;
             }
+
+            widget.updateSearchQuery(pattern);
+            // unselect to start a new search
+            widget.unSelectIngredient();
 
             return Provider.of<NutritionPlansProvider>(context, listen: false).searchIngredient(
               pattern,


### PR DESCRIPTION
# Proposed Changes

This PR adds a debounce time for TypeAhead-fields (exercises and ingredients) so that we don't overwhelm the server with each key stroke (since every entry in the result list could potentially result in a new request if the ingredient or exercise is not known locally in the app).

## Related Issue(s)

Closes #893 
