### PR TITLE
Make routineId nullable in session and related files

### DIFF
--- a/lib/models/workouts/session.dart
+++ b/lib/models/workouts/session.dart
@@ -31,7 +31,7 @@ class WorkoutSession {
   int? id;
 
   @JsonKey(required: true, name: 'routine')
-  late int routineId;
+  late int? routineId;
 
   @JsonKey(required: true, name: 'day')
   int? dayId;

--- a/lib/models/workouts/session.g.dart
+++ b/lib/models/workouts/session.g.dart
@@ -14,7 +14,7 @@ WorkoutSession _$WorkoutSessionFromJson(Map<String, dynamic> json) {
   return WorkoutSession(
     id: (json['id'] as num?)?.toInt(),
     dayId: (json['day'] as num?)?.toInt(),
-    routineId: (json['routine'] as num).toInt(),
+    routineId: (json['routine'] as num?)?.toInt(),
     impression: json['impression'] == null ? 2 : int.parse(json['impression'] as String),
     notes: json['notes'] as String? ?? '',
     timeStart: stringToTimeNull(json['time_start'] as String?),

--- a/lib/providers/routines.dart
+++ b/lib/providers/routines.dart
@@ -628,14 +628,17 @@ class RoutinesProvider with ChangeNotifier {
     return sessions;
   }
 
-  Future<WorkoutSession> addSession(WorkoutSession session, int routineId) async {
+  Future<WorkoutSession> addSession(WorkoutSession session, int? routineId) async {
     final data = await baseProvider.post(
       session.toJson(),
       baseProvider.makeUrl(_sessionUrlPath),
     );
     final newSession = WorkoutSession.fromJson(data);
-    final routine = findById(routineId);
-    routine.sessions.add(WorkoutSessionApi(session: newSession));
+
+    if (routineId != null) {
+      final routine = findById(routineId);
+      routine.sessions.add(WorkoutSessionApi(session: newSession));
+    }
 
     notifyListeners();
     return newSession;

--- a/lib/widgets/routines/forms/session.dart
+++ b/lib/widgets/routines/forms/session.dart
@@ -31,7 +31,7 @@ import 'package:wger/providers/routines.dart';
 class SessionForm extends StatefulWidget {
   final _logger = Logger('SessionForm');
   final WorkoutSession _session;
-  final int _routineId;
+  final int? _routineId;
   final Function()? _onSaved;
 
   static const SLIDER_START = -0.5;

--- a/lib/widgets/routines/log.dart
+++ b/lib/widgets/routines/log.dart
@@ -65,7 +65,7 @@ class _SessionInfoState extends State<SessionInfo> {
           ),
           if (editMode)
             SessionForm(
-              widget._session.routineId,
+              widget._session.routineId!,
               onSaved: () => setState(() => editMode = false),
               session: widget._session,
             )

--- a/test/auth/auth_screen_test.mocks.dart
+++ b/test/auth/auth_screen_test.mocks.dart
@@ -24,6 +24,7 @@ import 'package:mockito/src/dummies.dart' as _i5;
 // ignore_for_file: unnecessary_parenthesis
 // ignore_for_file: camel_case_types
 // ignore_for_file: subtype_of_sealed_class
+// ignore_for_file: invalid_use_of_internal_member
 
 class _FakeResponse_0 extends _i1.SmartFake implements _i2.Response {
   _FakeResponse_0(

--- a/test/core/settings_test.mocks.dart
+++ b/test/core/settings_test.mocks.dart
@@ -42,6 +42,7 @@ import 'package:wger/providers/user.dart' as _i22;
 // ignore_for_file: unnecessary_parenthesis
 // ignore_for_file: camel_case_types
 // ignore_for_file: subtype_of_sealed_class
+// ignore_for_file: invalid_use_of_internal_member
 
 class _FakeWgerBaseProvider_0 extends _i1.SmartFake implements _i2.WgerBaseProvider {
   _FakeWgerBaseProvider_0(
@@ -282,19 +283,19 @@ class MockExercisesProvider extends _i1.Mock implements _i17.ExercisesProvider {
       ) as List<_i8.Language>);
 
   @override
-  set database(_i3.ExerciseDatabase? _database) => super.noSuchMethod(
+  set database(_i3.ExerciseDatabase? value) => super.noSuchMethod(
         Invocation.setter(
           #database,
-          _database,
+          value,
         ),
         returnValueForMissingStub: null,
       );
 
   @override
-  set exercises(List<_i4.Exercise>? _exercises) => super.noSuchMethod(
+  set exercises(List<_i4.Exercise>? value) => super.noSuchMethod(
         Invocation.setter(
           #exercises,
-          _exercises,
+          value,
         ),
         returnValueForMissingStub: null,
       );
@@ -724,19 +725,19 @@ class MockNutritionPlansProvider extends _i1.Mock implements _i20.NutritionPlans
       ) as List<_i10.NutritionalPlan>);
 
   @override
-  set database(_i9.IngredientDatabase? _database) => super.noSuchMethod(
+  set database(_i9.IngredientDatabase? value) => super.noSuchMethod(
         Invocation.setter(
           #database,
-          _database,
+          value,
         ),
         returnValueForMissingStub: null,
       );
 
   @override
-  set ingredients(List<_i13.Ingredient>? _ingredients) => super.noSuchMethod(
+  set ingredients(List<_i13.Ingredient>? value) => super.noSuchMethod(
         Invocation.setter(
           #ingredients,
-          _ingredients,
+          value,
         ),
         returnValueForMissingStub: null,
       );
@@ -1149,28 +1150,28 @@ class MockUserProvider extends _i1.Mock implements _i22.UserProvider {
       ) as _i14.SharedPreferencesAsync);
 
   @override
-  set themeMode(_i23.ThemeMode? _themeMode) => super.noSuchMethod(
+  set themeMode(_i23.ThemeMode? value) => super.noSuchMethod(
         Invocation.setter(
           #themeMode,
-          _themeMode,
+          value,
         ),
         returnValueForMissingStub: null,
       );
 
   @override
-  set prefs(_i14.SharedPreferencesAsync? _prefs) => super.noSuchMethod(
+  set prefs(_i14.SharedPreferencesAsync? value) => super.noSuchMethod(
         Invocation.setter(
           #prefs,
-          _prefs,
+          value,
         ),
         returnValueForMissingStub: null,
       );
 
   @override
-  set profile(_i24.Profile? _profile) => super.noSuchMethod(
+  set profile(_i24.Profile? value) => super.noSuchMethod(
         Invocation.setter(
           #profile,
-          _profile,
+          value,
         ),
         returnValueForMissingStub: null,
       );
@@ -1293,19 +1294,19 @@ class MockWgerBaseProvider extends _i1.Mock implements _i2.WgerBaseProvider {
       ) as _i16.Client);
 
   @override
-  set auth(_i15.AuthProvider? _auth) => super.noSuchMethod(
+  set auth(_i15.AuthProvider? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
-          _auth,
+          value,
         ),
         returnValueForMissingStub: null,
       );
 
   @override
-  set client(_i16.Client? _client) => super.noSuchMethod(
+  set client(_i16.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #client,
-          _client,
+          value,
         ),
         returnValueForMissingStub: null,
       );

--- a/test/exercises/contribute_exercise_test.mocks.dart
+++ b/test/exercises/contribute_exercise_test.mocks.dart
@@ -38,6 +38,7 @@ import 'package:wger/providers/user.dart' as _i17;
 // ignore_for_file: unnecessary_parenthesis
 // ignore_for_file: camel_case_types
 // ignore_for_file: subtype_of_sealed_class
+// ignore_for_file: invalid_use_of_internal_member
 
 class _FakeWgerBaseProvider_0 extends _i1.SmartFake implements _i2.WgerBaseProvider {
   _FakeWgerBaseProvider_0(
@@ -233,19 +234,19 @@ class MockAddExerciseProvider extends _i1.Mock implements _i13.AddExerciseProvid
       ) as List<_i11.Muscle>);
 
   @override
-  set language(_i12.Language? _language) => super.noSuchMethod(
+  set language(_i12.Language? value) => super.noSuchMethod(
         Invocation.setter(
           #language,
-          _language,
+          value,
         ),
         returnValueForMissingStub: null,
       );
 
   @override
-  set category(_i9.ExerciseCategory? _category) => super.noSuchMethod(
+  set category(_i9.ExerciseCategory? value) => super.noSuchMethod(
         Invocation.setter(
           #category,
-          _category,
+          value,
         ),
         returnValueForMissingStub: null,
       );
@@ -551,28 +552,28 @@ class MockUserProvider extends _i1.Mock implements _i17.UserProvider {
       ) as _i7.SharedPreferencesAsync);
 
   @override
-  set themeMode(_i18.ThemeMode? _themeMode) => super.noSuchMethod(
+  set themeMode(_i18.ThemeMode? value) => super.noSuchMethod(
         Invocation.setter(
           #themeMode,
-          _themeMode,
+          value,
         ),
         returnValueForMissingStub: null,
       );
 
   @override
-  set prefs(_i7.SharedPreferencesAsync? _prefs) => super.noSuchMethod(
+  set prefs(_i7.SharedPreferencesAsync? value) => super.noSuchMethod(
         Invocation.setter(
           #prefs,
-          _prefs,
+          value,
         ),
         returnValueForMissingStub: null,
       );
 
   @override
-  set profile(_i19.Profile? _profile) => super.noSuchMethod(
+  set profile(_i19.Profile? value) => super.noSuchMethod(
         Invocation.setter(
           #profile,
-          _profile,
+          value,
         ),
         returnValueForMissingStub: null,
       );
@@ -737,19 +738,19 @@ class MockExercisesProvider extends _i1.Mock implements _i20.ExercisesProvider {
       ) as List<_i12.Language>);
 
   @override
-  set database(_i8.ExerciseDatabase? _database) => super.noSuchMethod(
+  set database(_i8.ExerciseDatabase? value) => super.noSuchMethod(
         Invocation.setter(
           #database,
-          _database,
+          value,
         ),
         returnValueForMissingStub: null,
       );
 
   @override
-  set exercises(List<_i3.Exercise>? _exercises) => super.noSuchMethod(
+  set exercises(List<_i3.Exercise>? value) => super.noSuchMethod(
         Invocation.setter(
           #exercises,
-          _exercises,
+          value,
         ),
         returnValueForMissingStub: null,
       );

--- a/test/exercises/exercises_detail_widget_test.mocks.dart
+++ b/test/exercises/exercises_detail_widget_test.mocks.dart
@@ -29,6 +29,7 @@ import 'package:wger/providers/exercises.dart' as _i9;
 // ignore_for_file: unnecessary_parenthesis
 // ignore_for_file: camel_case_types
 // ignore_for_file: subtype_of_sealed_class
+// ignore_for_file: invalid_use_of_internal_member
 
 class _FakeWgerBaseProvider_0 extends _i1.SmartFake implements _i2.WgerBaseProvider {
   _FakeWgerBaseProvider_0(
@@ -169,19 +170,19 @@ class MockExercisesProvider extends _i1.Mock implements _i9.ExercisesProvider {
       ) as List<_i8.Language>);
 
   @override
-  set database(_i3.ExerciseDatabase? _database) => super.noSuchMethod(
+  set database(_i3.ExerciseDatabase? value) => super.noSuchMethod(
         Invocation.setter(
           #database,
-          _database,
+          value,
         ),
         returnValueForMissingStub: null,
       );
 
   @override
-  set exercises(List<_i4.Exercise>? _exercises) => super.noSuchMethod(
+  set exercises(List<_i4.Exercise>? value) => super.noSuchMethod(
         Invocation.setter(
           #exercises,
-          _exercises,
+          value,
         ),
         returnValueForMissingStub: null,
       );

--- a/test/gallery/gallery_form_test.mocks.dart
+++ b/test/gallery/gallery_form_test.mocks.dart
@@ -26,6 +26,7 @@ import 'package:wger/providers/gallery.dart' as _i4;
 // ignore_for_file: unnecessary_parenthesis
 // ignore_for_file: camel_case_types
 // ignore_for_file: subtype_of_sealed_class
+// ignore_for_file: invalid_use_of_internal_member
 
 class _FakeAuthProvider_0 extends _i1.SmartFake implements _i2.AuthProvider {
   _FakeAuthProvider_0(
@@ -82,10 +83,10 @@ class MockGalleryProvider extends _i1.Mock implements _i4.GalleryProvider {
       ) as List<_i5.Image>);
 
   @override
-  set images(List<_i5.Image>? _images) => super.noSuchMethod(
+  set images(List<_i5.Image>? value) => super.noSuchMethod(
         Invocation.setter(
           #images,
-          _images,
+          value,
         ),
         returnValueForMissingStub: null,
       );
@@ -109,19 +110,19 @@ class MockGalleryProvider extends _i1.Mock implements _i4.GalleryProvider {
       ) as _i3.Client);
 
   @override
-  set auth(_i2.AuthProvider? _auth) => super.noSuchMethod(
+  set auth(_i2.AuthProvider? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
-          _auth,
+          value,
         ),
         returnValueForMissingStub: null,
       );
 
   @override
-  set client(_i3.Client? _client) => super.noSuchMethod(
+  set client(_i3.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #client,
-          _client,
+          value,
         ),
         returnValueForMissingStub: null,
       );

--- a/test/gallery/gallery_screen_test.mocks.dart
+++ b/test/gallery/gallery_screen_test.mocks.dart
@@ -26,6 +26,7 @@ import 'package:wger/providers/gallery.dart' as _i4;
 // ignore_for_file: unnecessary_parenthesis
 // ignore_for_file: camel_case_types
 // ignore_for_file: subtype_of_sealed_class
+// ignore_for_file: invalid_use_of_internal_member
 
 class _FakeAuthProvider_0 extends _i1.SmartFake implements _i2.AuthProvider {
   _FakeAuthProvider_0(
@@ -82,10 +83,10 @@ class MockGalleryProvider extends _i1.Mock implements _i4.GalleryProvider {
       ) as List<_i5.Image>);
 
   @override
-  set images(List<_i5.Image>? _images) => super.noSuchMethod(
+  set images(List<_i5.Image>? value) => super.noSuchMethod(
         Invocation.setter(
           #images,
-          _images,
+          value,
         ),
         returnValueForMissingStub: null,
       );
@@ -109,19 +110,19 @@ class MockGalleryProvider extends _i1.Mock implements _i4.GalleryProvider {
       ) as _i3.Client);
 
   @override
-  set auth(_i2.AuthProvider? _auth) => super.noSuchMethod(
+  set auth(_i2.AuthProvider? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
-          _auth,
+          value,
         ),
         returnValueForMissingStub: null,
       );
 
   @override
-  set client(_i3.Client? _client) => super.noSuchMethod(
+  set client(_i3.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #client,
-          _client,
+          value,
         ),
         returnValueForMissingStub: null,
       );

--- a/test/measurements/measurement_categories_screen_test.mocks.dart
+++ b/test/measurements/measurement_categories_screen_test.mocks.dart
@@ -25,6 +25,7 @@ import 'package:wger/providers/measurement.dart' as _i4;
 // ignore_for_file: unnecessary_parenthesis
 // ignore_for_file: camel_case_types
 // ignore_for_file: subtype_of_sealed_class
+// ignore_for_file: invalid_use_of_internal_member
 
 class _FakeWgerBaseProvider_0 extends _i1.SmartFake implements _i2.WgerBaseProvider {
   _FakeWgerBaseProvider_0(

--- a/test/measurements/measurement_provider_test.mocks.dart
+++ b/test/measurements/measurement_provider_test.mocks.dart
@@ -23,6 +23,7 @@ import 'package:wger/providers/base_provider.dart' as _i4;
 // ignore_for_file: unnecessary_parenthesis
 // ignore_for_file: camel_case_types
 // ignore_for_file: subtype_of_sealed_class
+// ignore_for_file: invalid_use_of_internal_member
 
 class _FakeAuthProvider_0 extends _i1.SmartFake implements _i2.AuthProvider {
   _FakeAuthProvider_0(
@@ -91,19 +92,19 @@ class MockWgerBaseProvider extends _i1.Mock implements _i4.WgerBaseProvider {
       ) as _i3.Client);
 
   @override
-  set auth(_i2.AuthProvider? _auth) => super.noSuchMethod(
+  set auth(_i2.AuthProvider? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
-          _auth,
+          value,
         ),
         returnValueForMissingStub: null,
       );
 
   @override
-  set client(_i3.Client? _client) => super.noSuchMethod(
+  set client(_i3.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #client,
-          _client,
+          value,
         ),
         returnValueForMissingStub: null,
       );

--- a/test/nutrition/nutritional_meal_form_test.mocks.dart
+++ b/test/nutrition/nutritional_meal_form_test.mocks.dart
@@ -29,6 +29,7 @@ import 'package:wger/providers/nutrition.dart' as _i8;
 // ignore_for_file: unnecessary_parenthesis
 // ignore_for_file: camel_case_types
 // ignore_for_file: subtype_of_sealed_class
+// ignore_for_file: invalid_use_of_internal_member
 
 class _FakeWgerBaseProvider_0 extends _i1.SmartFake implements _i2.WgerBaseProvider {
   _FakeWgerBaseProvider_0(
@@ -129,19 +130,19 @@ class MockNutritionPlansProvider extends _i1.Mock implements _i8.NutritionPlansP
       ) as List<_i4.NutritionalPlan>);
 
   @override
-  set database(_i3.IngredientDatabase? _database) => super.noSuchMethod(
+  set database(_i3.IngredientDatabase? value) => super.noSuchMethod(
         Invocation.setter(
           #database,
-          _database,
+          value,
         ),
         returnValueForMissingStub: null,
       );
 
   @override
-  set ingredients(List<_i7.Ingredient>? _ingredients) => super.noSuchMethod(
+  set ingredients(List<_i7.Ingredient>? value) => super.noSuchMethod(
         Invocation.setter(
           #ingredients,
-          _ingredients,
+          value,
         ),
         returnValueForMissingStub: null,
       );

--- a/test/nutrition/nutritional_plan_form_test.mocks.dart
+++ b/test/nutrition/nutritional_plan_form_test.mocks.dart
@@ -29,6 +29,7 @@ import 'package:wger/providers/nutrition.dart' as _i8;
 // ignore_for_file: unnecessary_parenthesis
 // ignore_for_file: camel_case_types
 // ignore_for_file: subtype_of_sealed_class
+// ignore_for_file: invalid_use_of_internal_member
 
 class _FakeWgerBaseProvider_0 extends _i1.SmartFake implements _i2.WgerBaseProvider {
   _FakeWgerBaseProvider_0(
@@ -129,19 +130,19 @@ class MockNutritionPlansProvider extends _i1.Mock implements _i8.NutritionPlansP
       ) as List<_i4.NutritionalPlan>);
 
   @override
-  set database(_i3.IngredientDatabase? _database) => super.noSuchMethod(
+  set database(_i3.IngredientDatabase? value) => super.noSuchMethod(
         Invocation.setter(
           #database,
-          _database,
+          value,
         ),
         returnValueForMissingStub: null,
       );
 
   @override
-  set ingredients(List<_i7.Ingredient>? _ingredients) => super.noSuchMethod(
+  set ingredients(List<_i7.Ingredient>? value) => super.noSuchMethod(
         Invocation.setter(
           #ingredients,
-          _ingredients,
+          value,
         ),
         returnValueForMissingStub: null,
       );

--- a/test/nutrition/nutritional_plan_screen_test.mocks.dart
+++ b/test/nutrition/nutritional_plan_screen_test.mocks.dart
@@ -28,6 +28,7 @@ import 'package:wger/providers/base_provider.dart' as _i4;
 // ignore_for_file: unnecessary_parenthesis
 // ignore_for_file: camel_case_types
 // ignore_for_file: subtype_of_sealed_class
+// ignore_for_file: invalid_use_of_internal_member
 
 class _FakeAuthProvider_0 extends _i1.SmartFake implements _i2.AuthProvider {
   _FakeAuthProvider_0(
@@ -106,19 +107,19 @@ class MockWgerBaseProvider extends _i1.Mock implements _i4.WgerBaseProvider {
       ) as _i3.Client);
 
   @override
-  set auth(_i2.AuthProvider? _auth) => super.noSuchMethod(
+  set auth(_i2.AuthProvider? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
-          _auth,
+          value,
         ),
         returnValueForMissingStub: null,
       );
 
   @override
-  set client(_i3.Client? _client) => super.noSuchMethod(
+  set client(_i3.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #client,
-          _client,
+          value,
         ),
         returnValueForMissingStub: null,
       );
@@ -282,73 +283,73 @@ class MockAuthProvider extends _i1.Mock implements _i2.AuthProvider {
       ) as bool);
 
   @override
-  set token(String? _token) => super.noSuchMethod(
+  set token(String? value) => super.noSuchMethod(
         Invocation.setter(
           #token,
-          _token,
+          value,
         ),
         returnValueForMissingStub: null,
       );
 
   @override
-  set serverUrl(String? _serverUrl) => super.noSuchMethod(
+  set serverUrl(String? value) => super.noSuchMethod(
         Invocation.setter(
           #serverUrl,
-          _serverUrl,
+          value,
         ),
         returnValueForMissingStub: null,
       );
 
   @override
-  set serverVersion(String? _serverVersion) => super.noSuchMethod(
+  set serverVersion(String? value) => super.noSuchMethod(
         Invocation.setter(
           #serverVersion,
-          _serverVersion,
+          value,
         ),
         returnValueForMissingStub: null,
       );
 
   @override
-  set applicationVersion(_i6.PackageInfo? _applicationVersion) => super.noSuchMethod(
+  set applicationVersion(_i6.PackageInfo? value) => super.noSuchMethod(
         Invocation.setter(
           #applicationVersion,
-          _applicationVersion,
+          value,
         ),
         returnValueForMissingStub: null,
       );
 
   @override
-  set metadata(Map<String, String>? _metadata) => super.noSuchMethod(
+  set metadata(Map<String, String>? value) => super.noSuchMethod(
         Invocation.setter(
           #metadata,
-          _metadata,
+          value,
         ),
         returnValueForMissingStub: null,
       );
 
   @override
-  set state(_i2.AuthState? _state) => super.noSuchMethod(
+  set state(_i2.AuthState? value) => super.noSuchMethod(
         Invocation.setter(
           #state,
-          _state,
+          value,
         ),
         returnValueForMissingStub: null,
       );
 
   @override
-  set client(_i3.Client? _client) => super.noSuchMethod(
+  set client(_i3.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #client,
-          _client,
+          value,
         ),
         returnValueForMissingStub: null,
       );
 
   @override
-  set dataInit(bool? _dataInit) => super.noSuchMethod(
+  set dataInit(bool? value) => super.noSuchMethod(
         Invocation.setter(
           #dataInit,
-          _dataInit,
+          value,
         ),
         returnValueForMissingStub: null,
       );

--- a/test/nutrition/nutritional_plans_screen_test.mocks.dart
+++ b/test/nutrition/nutritional_plans_screen_test.mocks.dart
@@ -28,6 +28,7 @@ import 'package:wger/providers/base_provider.dart' as _i8;
 // ignore_for_file: unnecessary_parenthesis
 // ignore_for_file: camel_case_types
 // ignore_for_file: subtype_of_sealed_class
+// ignore_for_file: invalid_use_of_internal_member
 
 class _FakeClient_0 extends _i1.SmartFake implements _i2.Client {
   _FakeClient_0(
@@ -121,73 +122,73 @@ class MockAuthProvider extends _i1.Mock implements _i3.AuthProvider {
       ) as bool);
 
   @override
-  set token(String? _token) => super.noSuchMethod(
+  set token(String? value) => super.noSuchMethod(
         Invocation.setter(
           #token,
-          _token,
+          value,
         ),
         returnValueForMissingStub: null,
       );
 
   @override
-  set serverUrl(String? _serverUrl) => super.noSuchMethod(
+  set serverUrl(String? value) => super.noSuchMethod(
         Invocation.setter(
           #serverUrl,
-          _serverUrl,
+          value,
         ),
         returnValueForMissingStub: null,
       );
 
   @override
-  set serverVersion(String? _serverVersion) => super.noSuchMethod(
+  set serverVersion(String? value) => super.noSuchMethod(
         Invocation.setter(
           #serverVersion,
-          _serverVersion,
+          value,
         ),
         returnValueForMissingStub: null,
       );
 
   @override
-  set applicationVersion(_i4.PackageInfo? _applicationVersion) => super.noSuchMethod(
+  set applicationVersion(_i4.PackageInfo? value) => super.noSuchMethod(
         Invocation.setter(
           #applicationVersion,
-          _applicationVersion,
+          value,
         ),
         returnValueForMissingStub: null,
       );
 
   @override
-  set metadata(Map<String, String>? _metadata) => super.noSuchMethod(
+  set metadata(Map<String, String>? value) => super.noSuchMethod(
         Invocation.setter(
           #metadata,
-          _metadata,
+          value,
         ),
         returnValueForMissingStub: null,
       );
 
   @override
-  set state(_i3.AuthState? _state) => super.noSuchMethod(
+  set state(_i3.AuthState? value) => super.noSuchMethod(
         Invocation.setter(
           #state,
-          _state,
+          value,
         ),
         returnValueForMissingStub: null,
       );
 
   @override
-  set client(_i2.Client? _client) => super.noSuchMethod(
+  set client(_i2.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #client,
-          _client,
+          value,
         ),
         returnValueForMissingStub: null,
       );
 
   @override
-  set dataInit(bool? _dataInit) => super.noSuchMethod(
+  set dataInit(bool? value) => super.noSuchMethod(
         Invocation.setter(
           #dataInit,
-          _dataInit,
+          value,
         ),
         returnValueForMissingStub: null,
       );
@@ -395,19 +396,19 @@ class MockWgerBaseProvider extends _i1.Mock implements _i8.WgerBaseProvider {
       ) as _i2.Client);
 
   @override
-  set auth(_i3.AuthProvider? _auth) => super.noSuchMethod(
+  set auth(_i3.AuthProvider? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
-          _auth,
+          value,
         ),
         returnValueForMissingStub: null,
       );
 
   @override
-  set client(_i2.Client? _client) => super.noSuchMethod(
+  set client(_i2.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #client,
-          _client,
+          value,
         ),
         returnValueForMissingStub: null,
       );

--- a/test/other/base_provider_test.mocks.dart
+++ b/test/other/base_provider_test.mocks.dart
@@ -24,6 +24,7 @@ import 'package:mockito/src/dummies.dart' as _i5;
 // ignore_for_file: unnecessary_parenthesis
 // ignore_for_file: camel_case_types
 // ignore_for_file: subtype_of_sealed_class
+// ignore_for_file: invalid_use_of_internal_member
 
 class _FakeResponse_0 extends _i1.SmartFake implements _i2.Response {
   _FakeResponse_0(

--- a/test/providers/plate_calculator_test.mocks.dart
+++ b/test/providers/plate_calculator_test.mocks.dart
@@ -21,6 +21,7 @@ import 'package:shared_preferences/src/shared_preferences_async.dart' as _i2;
 // ignore_for_file: unnecessary_parenthesis
 // ignore_for_file: camel_case_types
 // ignore_for_file: subtype_of_sealed_class
+// ignore_for_file: invalid_use_of_internal_member
 
 /// A class which mocks [SharedPreferencesAsync].
 ///

--- a/test/routine/day_form_test.mocks.dart
+++ b/test/routine/day_form_test.mocks.dart
@@ -35,6 +35,7 @@ import 'package:wger/providers/routines.dart' as _i12;
 // ignore_for_file: unnecessary_parenthesis
 // ignore_for_file: camel_case_types
 // ignore_for_file: subtype_of_sealed_class
+// ignore_for_file: invalid_use_of_internal_member
 
 class _FakeWgerBaseProvider_0 extends _i1.SmartFake implements _i2.WgerBaseProvider {
   _FakeWgerBaseProvider_0(
@@ -190,10 +191,10 @@ class MockRoutinesProvider extends _i1.Mock implements _i12.RoutinesProvider {
       ) as _i4.RepetitionUnit);
 
   @override
-  set activeRoutine(_i5.Routine? _activeRoutine) => super.noSuchMethod(
+  set activeRoutine(_i5.Routine? value) => super.noSuchMethod(
         Invocation.setter(
           #activeRoutine,
-          _activeRoutine,
+          value,
         ),
         returnValueForMissingStub: null,
       );

--- a/test/routine/forms/session_form_test.mocks.dart
+++ b/test/routine/forms/session_form_test.mocks.dart
@@ -35,6 +35,7 @@ import 'package:wger/providers/routines.dart' as _i12;
 // ignore_for_file: unnecessary_parenthesis
 // ignore_for_file: camel_case_types
 // ignore_for_file: subtype_of_sealed_class
+// ignore_for_file: invalid_use_of_internal_member
 
 class _FakeWgerBaseProvider_0 extends _i1.SmartFake implements _i2.WgerBaseProvider {
   _FakeWgerBaseProvider_0(
@@ -190,10 +191,10 @@ class MockRoutinesProvider extends _i1.Mock implements _i12.RoutinesProvider {
       ) as _i4.RepetitionUnit);
 
   @override
-  set activeRoutine(_i5.Routine? _activeRoutine) => super.noSuchMethod(
+  set activeRoutine(_i5.Routine? value) => super.noSuchMethod(
         Invocation.setter(
           #activeRoutine,
-          _activeRoutine,
+          value,
         ),
         returnValueForMissingStub: null,
       );

--- a/test/routine/gym_mode_screen_test.mocks.dart
+++ b/test/routine/gym_mode_screen_test.mocks.dart
@@ -43,6 +43,7 @@ import 'package:wger/providers/routines.dart' as _i23;
 // ignore_for_file: unnecessary_parenthesis
 // ignore_for_file: camel_case_types
 // ignore_for_file: subtype_of_sealed_class
+// ignore_for_file: invalid_use_of_internal_member
 
 class _FakeAuthProvider_0 extends _i1.SmartFake implements _i2.AuthProvider {
   _FakeAuthProvider_0(
@@ -271,19 +272,19 @@ class MockWgerBaseProvider extends _i1.Mock implements _i4.WgerBaseProvider {
       ) as _i3.Client);
 
   @override
-  set auth(_i2.AuthProvider? _auth) => super.noSuchMethod(
+  set auth(_i2.AuthProvider? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
-          _auth,
+          value,
         ),
         returnValueForMissingStub: null,
       );
 
   @override
-  set client(_i3.Client? _client) => super.noSuchMethod(
+  set client(_i3.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #client,
-          _client,
+          value,
         ),
         returnValueForMissingStub: null,
       );
@@ -474,19 +475,19 @@ class MockExercisesProvider extends _i1.Mock implements _i21.ExercisesProvider {
       ) as List<_i10.Language>);
 
   @override
-  set database(_i5.ExerciseDatabase? _database) => super.noSuchMethod(
+  set database(_i5.ExerciseDatabase? value) => super.noSuchMethod(
         Invocation.setter(
           #database,
-          _database,
+          value,
         ),
         returnValueForMissingStub: null,
       );
 
   @override
-  set exercises(List<_i6.Exercise>? _exercises) => super.noSuchMethod(
+  set exercises(List<_i6.Exercise>? value) => super.noSuchMethod(
         Invocation.setter(
           #exercises,
-          _exercises,
+          value,
         ),
         returnValueForMissingStub: null,
       );
@@ -931,10 +932,10 @@ class MockRoutinesProvider extends _i1.Mock implements _i23.RoutinesProvider {
       ) as _i12.RepetitionUnit);
 
   @override
-  set activeRoutine(_i13.Routine? _activeRoutine) => super.noSuchMethod(
+  set activeRoutine(_i13.Routine? value) => super.noSuchMethod(
         Invocation.setter(
           #activeRoutine,
-          _activeRoutine,
+          value,
         ),
         returnValueForMissingStub: null,
       );

--- a/test/routine/gym_mode_session_screen_test.mocks.dart
+++ b/test/routine/gym_mode_session_screen_test.mocks.dart
@@ -35,6 +35,7 @@ import 'package:wger/providers/routines.dart' as _i12;
 // ignore_for_file: unnecessary_parenthesis
 // ignore_for_file: camel_case_types
 // ignore_for_file: subtype_of_sealed_class
+// ignore_for_file: invalid_use_of_internal_member
 
 class _FakeWgerBaseProvider_0 extends _i1.SmartFake implements _i2.WgerBaseProvider {
   _FakeWgerBaseProvider_0(
@@ -190,10 +191,10 @@ class MockRoutinesProvider extends _i1.Mock implements _i12.RoutinesProvider {
       ) as _i4.RepetitionUnit);
 
   @override
-  set activeRoutine(_i5.Routine? _activeRoutine) => super.noSuchMethod(
+  set activeRoutine(_i5.Routine? value) => super.noSuchMethod(
         Invocation.setter(
           #activeRoutine,
-          _activeRoutine,
+          value,
         ),
         returnValueForMissingStub: null,
       );

--- a/test/routine/repetition_unit_form_widget_test.mocks.dart
+++ b/test/routine/repetition_unit_form_widget_test.mocks.dart
@@ -35,6 +35,7 @@ import 'package:wger/providers/routines.dart' as _i12;
 // ignore_for_file: unnecessary_parenthesis
 // ignore_for_file: camel_case_types
 // ignore_for_file: subtype_of_sealed_class
+// ignore_for_file: invalid_use_of_internal_member
 
 class _FakeWgerBaseProvider_0 extends _i1.SmartFake implements _i2.WgerBaseProvider {
   _FakeWgerBaseProvider_0(
@@ -190,10 +191,10 @@ class MockRoutinesProvider extends _i1.Mock implements _i12.RoutinesProvider {
       ) as _i4.RepetitionUnit);
 
   @override
-  set activeRoutine(_i5.Routine? _activeRoutine) => super.noSuchMethod(
+  set activeRoutine(_i5.Routine? value) => super.noSuchMethod(
         Invocation.setter(
           #activeRoutine,
-          _activeRoutine,
+          value,
         ),
         returnValueForMissingStub: null,
       );

--- a/test/routine/routine_edit_screen_test.mocks.dart
+++ b/test/routine/routine_edit_screen_test.mocks.dart
@@ -35,6 +35,7 @@ import 'package:wger/providers/routines.dart' as _i12;
 // ignore_for_file: unnecessary_parenthesis
 // ignore_for_file: camel_case_types
 // ignore_for_file: subtype_of_sealed_class
+// ignore_for_file: invalid_use_of_internal_member
 
 class _FakeWgerBaseProvider_0 extends _i1.SmartFake implements _i2.WgerBaseProvider {
   _FakeWgerBaseProvider_0(
@@ -190,10 +191,10 @@ class MockRoutinesProvider extends _i1.Mock implements _i12.RoutinesProvider {
       ) as _i4.RepetitionUnit);
 
   @override
-  set activeRoutine(_i5.Routine? _activeRoutine) => super.noSuchMethod(
+  set activeRoutine(_i5.Routine? value) => super.noSuchMethod(
         Invocation.setter(
           #activeRoutine,
-          _activeRoutine,
+          value,
         ),
         returnValueForMissingStub: null,
       );

--- a/test/routine/routine_edit_test.mocks.dart
+++ b/test/routine/routine_edit_test.mocks.dart
@@ -35,6 +35,7 @@ import 'package:wger/providers/routines.dart' as _i12;
 // ignore_for_file: unnecessary_parenthesis
 // ignore_for_file: camel_case_types
 // ignore_for_file: subtype_of_sealed_class
+// ignore_for_file: invalid_use_of_internal_member
 
 class _FakeWgerBaseProvider_0 extends _i1.SmartFake implements _i2.WgerBaseProvider {
   _FakeWgerBaseProvider_0(
@@ -190,10 +191,10 @@ class MockRoutinesProvider extends _i1.Mock implements _i12.RoutinesProvider {
       ) as _i4.RepetitionUnit);
 
   @override
-  set activeRoutine(_i5.Routine? _activeRoutine) => super.noSuchMethod(
+  set activeRoutine(_i5.Routine? value) => super.noSuchMethod(
         Invocation.setter(
           #activeRoutine,
-          _activeRoutine,
+          value,
         ),
         returnValueForMissingStub: null,
       );

--- a/test/routine/routine_form_test.mocks.dart
+++ b/test/routine/routine_form_test.mocks.dart
@@ -35,6 +35,7 @@ import 'package:wger/providers/routines.dart' as _i12;
 // ignore_for_file: unnecessary_parenthesis
 // ignore_for_file: camel_case_types
 // ignore_for_file: subtype_of_sealed_class
+// ignore_for_file: invalid_use_of_internal_member
 
 class _FakeWgerBaseProvider_0 extends _i1.SmartFake implements _i2.WgerBaseProvider {
   _FakeWgerBaseProvider_0(
@@ -190,10 +191,10 @@ class MockRoutinesProvider extends _i1.Mock implements _i12.RoutinesProvider {
       ) as _i4.RepetitionUnit);
 
   @override
-  set activeRoutine(_i5.Routine? _activeRoutine) => super.noSuchMethod(
+  set activeRoutine(_i5.Routine? value) => super.noSuchMethod(
         Invocation.setter(
           #activeRoutine,
-          _activeRoutine,
+          value,
         ),
         returnValueForMissingStub: null,
       );

--- a/test/routine/routine_logs_screen_test.mocks.dart
+++ b/test/routine/routine_logs_screen_test.mocks.dart
@@ -35,6 +35,7 @@ import 'package:wger/providers/routines.dart' as _i12;
 // ignore_for_file: unnecessary_parenthesis
 // ignore_for_file: camel_case_types
 // ignore_for_file: subtype_of_sealed_class
+// ignore_for_file: invalid_use_of_internal_member
 
 class _FakeWgerBaseProvider_0 extends _i1.SmartFake implements _i2.WgerBaseProvider {
   _FakeWgerBaseProvider_0(
@@ -190,10 +191,10 @@ class MockRoutinesProvider extends _i1.Mock implements _i12.RoutinesProvider {
       ) as _i4.RepetitionUnit);
 
   @override
-  set activeRoutine(_i5.Routine? _activeRoutine) => super.noSuchMethod(
+  set activeRoutine(_i5.Routine? value) => super.noSuchMethod(
         Invocation.setter(
           #activeRoutine,
-          _activeRoutine,
+          value,
         ),
         returnValueForMissingStub: null,
       );

--- a/test/routine/routine_screen_test.mocks.dart
+++ b/test/routine/routine_screen_test.mocks.dart
@@ -23,6 +23,7 @@ import 'package:wger/providers/base_provider.dart' as _i4;
 // ignore_for_file: unnecessary_parenthesis
 // ignore_for_file: camel_case_types
 // ignore_for_file: subtype_of_sealed_class
+// ignore_for_file: invalid_use_of_internal_member
 
 class _FakeAuthProvider_0 extends _i1.SmartFake implements _i2.AuthProvider {
   _FakeAuthProvider_0(
@@ -91,19 +92,19 @@ class MockWgerBaseProvider extends _i1.Mock implements _i4.WgerBaseProvider {
       ) as _i3.Client);
 
   @override
-  set auth(_i2.AuthProvider? _auth) => super.noSuchMethod(
+  set auth(_i2.AuthProvider? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
-          _auth,
+          value,
         ),
         returnValueForMissingStub: null,
       );
 
   @override
-  set client(_i3.Client? _client) => super.noSuchMethod(
+  set client(_i3.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #client,
-          _client,
+          value,
         ),
         returnValueForMissingStub: null,
       );

--- a/test/routine/routines_provider_test.mocks.dart
+++ b/test/routine/routines_provider_test.mocks.dart
@@ -31,6 +31,7 @@ import 'package:wger/providers/exercises.dart' as _i12;
 // ignore_for_file: unnecessary_parenthesis
 // ignore_for_file: camel_case_types
 // ignore_for_file: subtype_of_sealed_class
+// ignore_for_file: invalid_use_of_internal_member
 
 class _FakeAuthProvider_0 extends _i1.SmartFake implements _i2.AuthProvider {
   _FakeAuthProvider_0(
@@ -169,19 +170,19 @@ class MockWgerBaseProvider extends _i1.Mock implements _i4.WgerBaseProvider {
       ) as _i3.Client);
 
   @override
-  set auth(_i2.AuthProvider? _auth) => super.noSuchMethod(
+  set auth(_i2.AuthProvider? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
-          _auth,
+          value,
         ),
         returnValueForMissingStub: null,
       );
 
   @override
-  set client(_i3.Client? _client) => super.noSuchMethod(
+  set client(_i3.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #client,
-          _client,
+          value,
         ),
         returnValueForMissingStub: null,
       );
@@ -372,19 +373,19 @@ class MockExercisesProvider extends _i1.Mock implements _i12.ExercisesProvider {
       ) as List<_i10.Language>);
 
   @override
-  set database(_i5.ExerciseDatabase? _database) => super.noSuchMethod(
+  set database(_i5.ExerciseDatabase? value) => super.noSuchMethod(
         Invocation.setter(
           #database,
-          _database,
+          value,
         ),
         returnValueForMissingStub: null,
       );
 
   @override
-  set exercises(List<_i6.Exercise>? _exercises) => super.noSuchMethod(
+  set exercises(List<_i6.Exercise>? value) => super.noSuchMethod(
         Invocation.setter(
           #exercises,
-          _exercises,
+          value,
         ),
         returnValueForMissingStub: null,
       );

--- a/test/routine/routines_screen_test.mocks.dart
+++ b/test/routine/routines_screen_test.mocks.dart
@@ -23,6 +23,7 @@ import 'package:wger/providers/base_provider.dart' as _i4;
 // ignore_for_file: unnecessary_parenthesis
 // ignore_for_file: camel_case_types
 // ignore_for_file: subtype_of_sealed_class
+// ignore_for_file: invalid_use_of_internal_member
 
 class _FakeAuthProvider_0 extends _i1.SmartFake implements _i2.AuthProvider {
   _FakeAuthProvider_0(
@@ -91,19 +92,19 @@ class MockWgerBaseProvider extends _i1.Mock implements _i4.WgerBaseProvider {
       ) as _i3.Client);
 
   @override
-  set auth(_i2.AuthProvider? _auth) => super.noSuchMethod(
+  set auth(_i2.AuthProvider? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
-          _auth,
+          value,
         ),
         returnValueForMissingStub: null,
       );
 
   @override
-  set client(_i3.Client? _client) => super.noSuchMethod(
+  set client(_i3.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #client,
-          _client,
+          value,
         ),
         returnValueForMissingStub: null,
       );

--- a/test/routine/slot_entry_form_test.mocks.dart
+++ b/test/routine/slot_entry_form_test.mocks.dart
@@ -35,6 +35,7 @@ import 'package:wger/providers/routines.dart' as _i12;
 // ignore_for_file: unnecessary_parenthesis
 // ignore_for_file: camel_case_types
 // ignore_for_file: subtype_of_sealed_class
+// ignore_for_file: invalid_use_of_internal_member
 
 class _FakeWgerBaseProvider_0 extends _i1.SmartFake implements _i2.WgerBaseProvider {
   _FakeWgerBaseProvider_0(
@@ -190,10 +191,10 @@ class MockRoutinesProvider extends _i1.Mock implements _i12.RoutinesProvider {
       ) as _i4.RepetitionUnit);
 
   @override
-  set activeRoutine(_i5.Routine? _activeRoutine) => super.noSuchMethod(
+  set activeRoutine(_i5.Routine? value) => super.noSuchMethod(
         Invocation.setter(
           #activeRoutine,
-          _activeRoutine,
+          value,
         ),
         returnValueForMissingStub: null,
       );

--- a/test/routine/weight_unit_form_widget_test.mocks.dart
+++ b/test/routine/weight_unit_form_widget_test.mocks.dart
@@ -35,6 +35,7 @@ import 'package:wger/providers/routines.dart' as _i12;
 // ignore_for_file: unnecessary_parenthesis
 // ignore_for_file: camel_case_types
 // ignore_for_file: subtype_of_sealed_class
+// ignore_for_file: invalid_use_of_internal_member
 
 class _FakeWgerBaseProvider_0 extends _i1.SmartFake implements _i2.WgerBaseProvider {
   _FakeWgerBaseProvider_0(
@@ -190,10 +191,10 @@ class MockRoutinesProvider extends _i1.Mock implements _i12.RoutinesProvider {
       ) as _i4.RepetitionUnit);
 
   @override
-  set activeRoutine(_i5.Routine? _activeRoutine) => super.noSuchMethod(
+  set activeRoutine(_i5.Routine? value) => super.noSuchMethod(
         Invocation.setter(
           #activeRoutine,
-          _activeRoutine,
+          value,
         ),
         returnValueForMissingStub: null,
       );

--- a/test/user/provider_test.mocks.dart
+++ b/test/user/provider_test.mocks.dart
@@ -23,6 +23,7 @@ import 'package:wger/providers/base_provider.dart' as _i4;
 // ignore_for_file: unnecessary_parenthesis
 // ignore_for_file: camel_case_types
 // ignore_for_file: subtype_of_sealed_class
+// ignore_for_file: invalid_use_of_internal_member
 
 class _FakeAuthProvider_0 extends _i1.SmartFake implements _i2.AuthProvider {
   _FakeAuthProvider_0(
@@ -91,19 +92,19 @@ class MockWgerBaseProvider extends _i1.Mock implements _i4.WgerBaseProvider {
       ) as _i3.Client);
 
   @override
-  set auth(_i2.AuthProvider? _auth) => super.noSuchMethod(
+  set auth(_i2.AuthProvider? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
-          _auth,
+          value,
         ),
         returnValueForMissingStub: null,
       );
 
   @override
-  set client(_i3.Client? _client) => super.noSuchMethod(
+  set client(_i3.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #client,
-          _client,
+          value,
         ),
         returnValueForMissingStub: null,
       );

--- a/test/weight/weight_provider_test.mocks.dart
+++ b/test/weight/weight_provider_test.mocks.dart
@@ -23,6 +23,7 @@ import 'package:wger/providers/base_provider.dart' as _i4;
 // ignore_for_file: unnecessary_parenthesis
 // ignore_for_file: camel_case_types
 // ignore_for_file: subtype_of_sealed_class
+// ignore_for_file: invalid_use_of_internal_member
 
 class _FakeAuthProvider_0 extends _i1.SmartFake implements _i2.AuthProvider {
   _FakeAuthProvider_0(
@@ -91,19 +92,19 @@ class MockWgerBaseProvider extends _i1.Mock implements _i4.WgerBaseProvider {
       ) as _i3.Client);
 
   @override
-  set auth(_i2.AuthProvider? _auth) => super.noSuchMethod(
+  set auth(_i2.AuthProvider? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
-          _auth,
+          value,
         ),
         returnValueForMissingStub: null,
       );
 
   @override
-  set client(_i3.Client? _client) => super.noSuchMethod(
+  set client(_i3.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #client,
-          _client,
+          value,
         ),
         returnValueForMissingStub: null,
       );

--- a/test/weight/weight_screen_test.mocks.dart
+++ b/test/weight/weight_screen_test.mocks.dart
@@ -35,6 +35,7 @@ import 'package:wger/providers/user.dart' as _i13;
 // ignore_for_file: unnecessary_parenthesis
 // ignore_for_file: camel_case_types
 // ignore_for_file: subtype_of_sealed_class
+// ignore_for_file: invalid_use_of_internal_member
 
 class _FakeWgerBaseProvider_0 extends _i1.SmartFake implements _i2.WgerBaseProvider {
   _FakeWgerBaseProvider_0(
@@ -298,28 +299,28 @@ class MockUserProvider extends _i1.Mock implements _i13.UserProvider {
       ) as _i4.SharedPreferencesAsync);
 
   @override
-  set themeMode(_i14.ThemeMode? _themeMode) => super.noSuchMethod(
+  set themeMode(_i14.ThemeMode? value) => super.noSuchMethod(
         Invocation.setter(
           #themeMode,
-          _themeMode,
+          value,
         ),
         returnValueForMissingStub: null,
       );
 
   @override
-  set prefs(_i4.SharedPreferencesAsync? _prefs) => super.noSuchMethod(
+  set prefs(_i4.SharedPreferencesAsync? value) => super.noSuchMethod(
         Invocation.setter(
           #prefs,
-          _prefs,
+          value,
         ),
         returnValueForMissingStub: null,
       );
 
   @override
-  set profile(_i15.Profile? _profile) => super.noSuchMethod(
+  set profile(_i15.Profile? value) => super.noSuchMethod(
         Invocation.setter(
           #profile,
-          _profile,
+          value,
         ),
         returnValueForMissingStub: null,
       );
@@ -454,19 +455,19 @@ class MockNutritionPlansProvider extends _i1.Mock implements _i16.NutritionPlans
       ) as List<_i6.NutritionalPlan>);
 
   @override
-  set database(_i5.IngredientDatabase? _database) => super.noSuchMethod(
+  set database(_i5.IngredientDatabase? value) => super.noSuchMethod(
         Invocation.setter(
           #database,
-          _database,
+          value,
         ),
         returnValueForMissingStub: null,
       );
 
   @override
-  set ingredients(List<_i9.Ingredient>? _ingredients) => super.noSuchMethod(
+  set ingredients(List<_i9.Ingredient>? value) => super.noSuchMethod(
         Invocation.setter(
           #ingredients,
-          _ingredients,
+          value,
         ),
         returnValueForMissingStub: null,
       );


### PR DESCRIPTION
# Proposed Changes

Sessions can be added ad-hoc, without needing to be part of any specific routine.

## Related Issue(s)

Closes #896