### PR TITLE
AVIF: updated gallery widget to display message for non supported avif image type

### DIFF
--- a/lib/l10n/app_ca.arb
+++ b/lib/l10n/app_ca.arb
@@ -471,10 +471,26 @@
   },
   "gallery": "Galeria",
   "@gallery": {},
-  "galleryAvifNotSupported": "AVIF no és compatible",
-  "@galleryAvifNotSupported": {},
-  "galleryAvifNotSupportedDetail": "Les imatges AVIF encara no són compatibles.",
-  "@galleryAvifNotSupportedDetail": {},
+  "imageFormatNotSupported": "{imageFormat} no és compatible",
+  "@imageFormatNotSupported": {
+      "description": "Label shown on the error container when image format is not supported",
+      "type": "text",
+      "placeholders": {
+          "imageFormat": {
+              "type": "String"
+          }
+      }
+  },
+  "imageFormatNotSupportedDetail": "Les imatges {imageFormat} encara no són compatibles.",
+  "@imageFormatNotSupportedDetail": {
+      "description": "Label shown on the image preview container when image format is not supported",
+      "type": "text",
+      "placeholders": {
+          "imageFormat": {
+              "type": "String"
+          }
+      }
+  },
   "addImage": "Afegeix imatge",
   "@addImage": {},
   "dataCopied": "Dades copiades a una nova entrada",

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -508,10 +508,26 @@
   "@takePicture": {},
   "gallery": "Galerie",
   "@gallery": {},
-  "galleryAvifNotSupported": "AVIF není podporován",
-  "@galleryAvifNotSupported": {},
-  "galleryAvifNotSupportedDetail": "Obrazy AVIF zatím nejsou podporovány.",
-  "@galleryAvifNotSupportedDetail": {},
+  "imageFormatNotSupported": "{imageFormat} není podporován",
+  "@imageFormatNotSupported": {
+      "description": "Label shown on the error container when image format is not supported",
+      "type": "text",
+      "placeholders": {
+          "imageFormat": {
+              "type": "String"
+          }
+      }
+  },
+  "imageFormatNotSupportedDetail": "Obrazy {imageFormat} zatím nejsou podporovány.",
+  "@imageFormatNotSupportedDetail": {
+      "description": "Label shown on the image preview container when image format is not supported",
+      "type": "text",
+      "placeholders": {
+          "imageFormat": {
+              "type": "String"
+          }
+      }
+  },
   "productFound": "Produkt nalezen",
   "@productFound": {
     "description": "Header label for dialog when product is found with barcode"

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -357,10 +357,26 @@
     "@addImage": {},
     "gallery": "Galerie",
     "@gallery": {},
-    "galleryAvifNotSupported": "AVIF wird nicht unterstützt",
-    "@galleryAvifNotSupported": {},
-    "galleryAvifNotSupportedDetail": "AVIF-Bilder werden noch nicht unterstützt.",
-    "@galleryAvifNotSupportedDetail": {},
+    "imageFormatNotSupported": "{imageFormat} wird nicht unterstützt",
+    "@imageFormatNotSupported": {
+        "description": "Label shown on the error container when image format is not supported",
+        "type": "text",
+        "placeholders": {
+            "imageFormat": {
+                "type": "String"
+            }
+        }
+    },
+    "imageFormatNotSupportedDetail": "{imageFormat}-Bilder werden noch nicht unterstützt.",
+    "@imageFormatNotSupportedDetail": {
+        "description": "Label shown on the image preview container when image format is not supported",
+        "type": "text",
+        "placeholders": {
+            "imageFormat": {
+                "type": "String"
+            }
+        }
+    },
     "chooseFromLibrary": "Wähle aus der Bibliothek",
     "@chooseFromLibrary": {},
     "takePicture": "Bild aufnehmen",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -680,10 +680,6 @@
   "@chooseFromLibrary": {},
   "gallery": "Gallery",
   "@gallery": {},
-  "galleryAvifNotSupported": "AVIF not supported",
-  "@galleryAvifNotSupported": {},
-  "galleryAvifNotSupportedDetail": "AVIF images are not supported yet.",
-  "@galleryAvifNotSupportedDetail": {},
   "addImage": "Add image",
   "@addImage": {},
   "dataCopied": "Data copied to new entry",
@@ -775,6 +771,26 @@
   },
   "imageDetailsLicenseNotice": "By submitting this image, you agree to release it under the CC-BY-SA-4. The image must be either your own work or the author must have released it under a license compatible with it.",
   "imageDetailsLicenseNoticeLinkToLicense": "See license text.",
+  "imageFormatNotSupported": "{imageFormat} not supported",
+  "@imageFormatNotSupported": {
+      "description": "Label shown on the error container when image format is not supported",
+      "type": "text",
+      "placeholders": {
+          "imageFormat": {
+              "type": "String"
+          }
+      }
+  },
+  "imageFormatNotSupportedDetail": "{imageFormat} images are not supported yet.",
+  "@imageFormatNotSupportedDetail": {
+      "description": "Label shown on the image preview container when image format is not supported",
+      "type": "text",
+      "placeholders": {
+          "imageFormat": {
+              "type": "String"
+          }
+      }
+  },
   "add": "add",
   "@add": {
     "description": "Add button text"
@@ -1035,5 +1051,21 @@
   "themeMode": "Theme mode",
   "darkMode": "Always dark mode",
   "lightMode": "Always light mode",
-  "systemMode": "System settings"
+  "systemMode": "System settings",
+  "galleryImageTypeNotSupported": "{imageType} images are currently not supported on this platform.",
+  "@galleryImageTypeNotSupported": {
+    "placeholders": {
+      "imageType": {
+        "type": "String"
+      }
+    }
+  },
+  "galleryImageTypeNotSupportedDetail": "This image is in {imageType} format, which is currently not supported on this platform.",
+  "@galleryImageTypeNotSupportedDetail": {
+    "placeholders": {
+      "imageType": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -344,10 +344,26 @@
     "@addImage": {},
     "gallery": "Galería",
     "@gallery": {},
-    "galleryAvifNotSupported": "AVIF no compatible",
-    "@galleryAvifNotSupported": {},
-    "galleryAvifNotSupportedDetail": "Las imágenes AVIF aún no son compatibles.",
-    "@galleryAvifNotSupportedDetail": {},
+    "imageFormatNotSupported": "{imageFormat} no compatible",
+    "@imageFormatNotSupported": {
+        "description": "Label shown on the error container when image format is not supported",
+        "type": "text",
+        "placeholders": {
+            "imageFormat": {
+                "type": "String"
+            }
+        }
+    },
+    "imageFormatNotSupportedDetail": "Las imágenes {imageFormat} aún no son compatibles.",
+    "@imageFormatNotSupportedDetail": {
+        "description": "Label shown on the image preview container when image format is not supported",
+        "type": "text",
+        "placeholders": {
+            "imageFormat": {
+                "type": "String"
+            }
+        }
+    },
     "chooseFromLibrary": "Elije de la biblioteca de fotos",
     "@chooseFromLibrary": {},
     "takePicture": "Toma una foto",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -354,10 +354,26 @@
     "@addImage": {},
     "gallery": "Galerie",
     "@gallery": {},
-    "galleryAvifNotSupported": "AVIF non pris en charge",
-    "@galleryAvifNotSupported": {},
-    "galleryAvifNotSupportedDetail": "AVIF non pris en charge",
-    "@galleryAvifNotSupportedDetail": {},
+    "imageFormatNotSupported": "{imageFormat} non pris en charge",
+    "@imageFormatNotSupported": {
+        "description": "Label shown on the error container when image format is not supported",
+        "type": "text",
+        "placeholders": {
+            "imageFormat": {
+                "type": "String"
+            }
+        }
+    },
+    "imageFormatNotSupportedDetail": "{imageFormat} non pris en charge",
+    "@imageFormatNotSupportedDetail": {
+        "description": "Label shown on the image preview container when image format is not supported",
+        "type": "text",
+        "placeholders": {
+            "imageFormat": {
+                "type": "String"
+            }
+        }
+    },
     "chooseFromLibrary": "Choisir depuis la bibliothèque",
     "@chooseFromLibrary": {},
     "takePicture": "Prendre une photo",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -473,10 +473,26 @@
     "@chooseFromLibrary": {},
     "gallery": "Gallery",
     "@gallery": {},
-    "galleryAvifNotSupported": "AVIFはサポートされていません",
-    "@galleryAvifNotSupported": {},
-    "galleryAvifNotSupportedDetail": "AVIF形式の画像はまだサポートされていません。",
-    "@galleryAvifNotSupportedDetail": {},
+    "imageFormatNotSupported": "{imageFormat}はサポートされていません",
+    "@imageFormatNotSupported": {
+        "description": "Label shown on the error container when image format is not supported",
+        "type": "text",
+        "placeholders": {
+            "imageFormat": {
+                "type": "String"
+            }
+        }
+    },
+    "imageFormatNotSupportedDetail": "{imageFormat}形式の画像はまだサポートされていません。",
+    "@imageFormatNotSupportedDetail": {
+        "description": "Label shown on the image preview container when image format is not supported",
+        "type": "text",
+        "placeholders": {
+            "imageFormat": {
+                "type": "String"
+            }
+        }
+    },
     "addImage": "Add image",
     "@addImage": {},
     "dataCopied": "Data copied to new entry",

--- a/lib/l10n/app_uk.arb
+++ b/lib/l10n/app_uk.arb
@@ -479,10 +479,26 @@
     "@chooseFromLibrary": {},
     "gallery": "Галерея",
     "@gallery": {},
-    "galleryAvifNotSupported": "AVIF не підтримується",
-    "@galleryAvifNotSupported": {},
-    "galleryAvifNotSupportedDetail": "Зображення AVIF поки що не підтримуються.",
-    "@galleryAvifNotSupportedDetail": {},
+    "imageFormatNotSupported": "{imageFormat} не підтримується",
+    "@imageFormatNotSupported": {
+        "description": "Label shown on the error container when image format is not supported",
+        "type": "text",
+        "placeholders": {
+            "imageFormat": {
+                "type": "String"
+            }
+        }
+    },
+    "imageFormatNotSupportedDetail": "Зображення {imageFormat} поки що не підтримуються.",
+    "@imageFormatNotSupportedDetail": {
+        "description": "Label shown on the image preview container when image format is not supported",
+        "type": "text",
+        "placeholders": {
+            "imageFormat": {
+                "type": "String"
+            }
+        }
+    },
     "addImage": "Додати зображення",
     "@addImage": {},
     "dataCopied": "Дані скопійовано до нового запису",

--- a/lib/widgets/gallery/overview.dart
+++ b/lib/widgets/gallery/overview.dart
@@ -36,6 +36,7 @@ class Gallery extends StatelessWidget {
   Widget build(BuildContext context) {
     final provider = Provider.of<GalleryProvider>(context);
     final i18n = AppLocalizations.of(context);
+    final theme = Theme.of(context);
 
     return Padding(
       padding: const EdgeInsets.all(5),
@@ -58,20 +59,30 @@ class Gallery extends StatelessWidget {
                         context: context,
                       );
                     },
-                    child: currentImage.url!.toLowerCase().endsWith('.avif')
-                        ? AspectRatio(
-                            aspectRatio: 1,
-                            child: Center(
-                              child: Text(i18n.galleryAvifNotSupported),
+                    child: FadeInImage(
+                      key: Key('image-${currentImage.id!}'),
+                      placeholder: const AssetImage('assets/images/placeholder.png'),
+                      image: NetworkImage(currentImage.url!),
+                      fit: BoxFit.cover,
+                      imageSemanticLabel: currentImage.description,
+                      imageErrorBuilder: (context, error, stackTrace) {
+                        final imageFormat = currentImage.url!.split('.').last.toUpperCase();
+                        return AspectRatio(
+                          aspectRatio: 1,
+                          child: Container(
+                            color: theme.colorScheme.errorContainer,
+                            child: Row(
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              spacing: 8,
+                              children: [
+                                Icon(Icons.broken_image),
+                                Text(i18n.imageFormatNotSupported(imageFormat)), 
+                              ]
                             ),
-                          )
-                        : FadeInImage(
-                            key: Key('image-${currentImage.id!}'),
-                            placeholder: const AssetImage('assets/images/placeholder.png'),
-                            image: NetworkImage(currentImage.url!),
-                            fit: BoxFit.cover,
-                            imageSemanticLabel: currentImage.description,
                           ),
+                        );
+                      },
+                    ),
                   );
                 },
               ),
@@ -91,6 +102,7 @@ class ImageDetail extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final i18n = AppLocalizations.of(context);
+    final theme = Theme.of(context);
     return Container(
       key: Key('image-${image.id!}-detail'),
       padding: const EdgeInsets.all(10),
@@ -101,11 +113,25 @@ class ImageDetail extends StatelessWidget {
             style: Theme.of(context).textTheme.headlineSmall,
           ),
           Expanded(
-            child: image.url!.toLowerCase().endsWith('.avif')
-                ? Center(
-                    child: Text(i18n.galleryAvifNotSupportedDetail),
-                  )
-                : Image.network(image.url!, semanticLabel: image.description),
+            child: Image.network(
+              image.url!,
+              semanticLabel: image.description,
+              errorBuilder: (context, error, stackTrace) {
+                final imageFormat = image.url!.split('.').last.toUpperCase();
+
+                return Container(
+                  color: theme.colorScheme.errorContainer,
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    spacing: 8,
+                    children: [
+                      Icon(Icons.broken_image),
+                      Text(i18n.imageFormatNotSupportedDetail(imageFormat))
+                    ]
+                  ),
+                );
+              },
+            ),
           ),
           Padding(
             padding: const EdgeInsets.symmetric(vertical: 8),


### PR DESCRIPTION
# Changes Made

Currently we don't allow avif images to be uploaded, even if nothing speaks against it since all mayor browsers support it.

## Done:

- [x] check if this works on the flutter app, since flutter itself doesn't support it and relies on the underlying OS. If not, gracefully handle this and display an error message to the user

- [x] update any i18n strings in the react or flutter app


## Related Issue(s)

[#2082](https://github.com/wger-project/wger/issues/2082)

## Demo Screenshots
<img width="404" height="689" alt="image" src="https://github.com/user-attachments/assets/a1da00e7-60cc-460b-b985-18682cddbfdb" />
<img width="402" height="690" alt="image" src="https://github.com/user-attachments/assets/923647b1-c77c-49bf-a4c7-3013e2e95cc1" />


## Please check that the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Set a 100 character limit in your editor/IDE to avoid white space diffs in the PR
  (run `dart format .`)
- [x] Updated/added relevant documentation (doc comments with `///`).
- [x] Added relevant reviewers.
