### PR TITLE
AVIF: cleanup for non used translations as we are using more generic messages (imageFormatNotSupported and imageFormatNotSupportedDetail)

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1051,21 +1051,5 @@
   "themeMode": "Theme mode",
   "darkMode": "Always dark mode",
   "lightMode": "Always light mode",
-  "systemMode": "System settings",
-  "galleryImageTypeNotSupported": "{imageType} images are currently not supported on this platform.",
-  "@galleryImageTypeNotSupported": {
-    "placeholders": {
-      "imageType": {
-        "type": "String"
-      }
-    }
-  },
-  "galleryImageTypeNotSupportedDetail": "This image is in {imageType} format, which is currently not supported on this platform.",
-  "@galleryImageTypeNotSupportedDetail": {
-    "placeholders": {
-      "imageType": {
-        "type": "String"
-      }
-    }
-  }
+  "systemMode": "System settings"
 }


### PR DESCRIPTION
# Proposed Changes
Updated translations for en language to remove unused **galleryImageTypeNotSupported** and **galleryImageTypeNotSupportedDetail** since we are using more generic **imageFormatNotSupported** and **imageFormatNotSupportedDetail** naming.

## Related Issue(s)
[#2082](https://github.com/wger-project/wger/issues/2082)
## Please check that the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Set a 100 character limit in your editor/IDE to avoid white space diffs in the PR
  (run `dart format .`)
- [x] Updated/added relevant documentation (doc comments with `///`).
- [x] Added relevant reviewers.
