### PR TITLE
Feature/end_workout_button in "jump to" section

### DIFF
--- a/lib/widgets/routines/gym_mode/exercise_overview.dart
+++ b/lib/widgets/routines/gym_mode/exercise_overview.dart
@@ -42,7 +42,7 @@ class ExerciseOverview extends StatelessWidget {
         NavigationHeader(
           _exercise.getTranslation(Localizations.localeOf(context).languageCode).name,
           _controller,
-          _totalPages,
+          totalPages: _totalPages,
           exercisePages: _exercisePages,
         ),
         Expanded(

--- a/lib/widgets/routines/gym_mode/log_page.dart
+++ b/lib/widgets/routines/gym_mode/log_page.dart
@@ -268,7 +268,7 @@ class _LogPageState extends ConsumerState<LogPage> {
         NavigationHeader(
           widget._exercise.getTranslation(Localizations.localeOf(context).languageCode).name,
           widget._controller,
-          widget._totalPages,
+          totalPages: widget._totalPages,
           exercisePages: widget._exercisePages,
         ),
 

--- a/lib/widgets/routines/gym_mode/navigation.dart
+++ b/lib/widgets/routines/gym_mode/navigation.dart
@@ -79,22 +79,22 @@ class NavigationHeader extends StatelessWidget {
   final PageController _controller;
   final String _title;
   final Map<Exercise, int> exercisePages;
-  final int ?_totalPages;
+  final int ?totalPages;
 
   const NavigationHeader(
     this._title,
-    this._controller,
-    this._totalPages, {
-    required this.exercisePages
-  });
+    this._controller, {
+      this.totalPages,
+      required this.exercisePages
+    });
 
   Widget getDialog(BuildContext context) {
-    final TextButton? endWorkoutButton = _totalPages != null
+    final TextButton? endWorkoutButton = totalPages != null
         ? TextButton(
             child: Text(AppLocalizations.of(context).endWorkout),
             onPressed: () {
               _controller.animateToPage(
-                _totalPages!,
+                totalPages!,
                 duration: DEFAULT_ANIMATION_DURATION,
                 curve: DEFAULT_ANIMATION_CURVE,
               );

--- a/lib/widgets/routines/gym_mode/session_page.dart
+++ b/lib/widgets/routines/gym_mode/session_page.dart
@@ -59,7 +59,6 @@ class SessionPage extends StatelessWidget {
         NavigationHeader(
           AppLocalizations.of(context).workoutSession,
           _controller,
-          null,
           exercisePages: _exercisePages,
         ),
         Expanded(child: Container()),

--- a/lib/widgets/routines/gym_mode/start_page.dart
+++ b/lib/widgets/routines/gym_mode/start_page.dart
@@ -19,7 +19,6 @@ class StartPage extends StatelessWidget {
         NavigationHeader(
           AppLocalizations.of(context).todaysWorkout,
           _controller,
-          null,
           exercisePages: _exercisePages,
         ),
         Expanded(

--- a/lib/widgets/routines/gym_mode/timer.dart
+++ b/lib/widgets/routines/gym_mode/timer.dart
@@ -69,7 +69,7 @@ class _TimerWidgetState extends State<TimerWidget> {
         NavigationHeader(
           AppLocalizations.of(context).pause,
           widget._controller,
-          widget._totalPages,
+          totalPages: widget._totalPages,
           exercisePages: widget._exercisePages,
         ),
         Expanded(
@@ -137,7 +137,7 @@ class _TimerCountdownWidgetState extends State<TimerCountdownWidget> {
         NavigationHeader(
           AppLocalizations.of(context).pause,
           widget._controller,
-          widget._totalPages,
+          totalPages: widget._totalPages,
           exercisePages: widget._exercisePages,
         ),
         Expanded(


### PR DESCRIPTION
# Proposed Changes
Added a button to end workout in the "jump to" section during gym mode. 

This button is not accessible from `start_page.dart` nor `session_page.dart` in the jump_to section. This is an arbitrary choice, as ending a workout without having started it, or ending an ended workout doesn't seem logical. 

Other than that, the button is accessible from other pages of the gym mode.

In order for the end workout button to work, using the `_controller.animateToPage(...)`, I needed to know how many pages there were. I therefore added a `_totalPages` attribute in `gym_mode.dart`, that is calculated in already-existing function `_calculatePages()`. 

![Screen Recording 2025-10-13 at 23 57 17](https://github.com/user-attachments/assets/a0aece03-7867-4b1f-897f-58f66138243c)

## Related Issue(s)
Closes #920 : *Option to end workout in the "jump to" section*

## Please check that the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features) **-> doesn't seem to have any existing test files for widgets**
- [X] Set a 100 character limit in your editor/IDE to avoid white space diffs in the PR
  (run `dart format .`)
- [ ] Updated/added relevant documentation (doc comments with `///`). **-> doesn't seem to have an existing doc for that part**
- [ ] Added relevant reviewers. 

Waiting for your feedback to rework on necessary parts :).
