### PR TITLE
Hide debug banner in main MaterialApp

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -220,6 +220,7 @@ class MainApp extends StatelessWidget {
         builder: (ctx, auth, _) => Consumer<UserProvider>(
           builder: (ctx, user, _) => MaterialApp(
             title: 'wger',
+            debugShowCheckedModeBanner: false,
             navigatorKey: navigatorKey,
             theme: wgerLightTheme,
             darkTheme: wgerDarkTheme,


### PR DESCRIPTION
This PR disables the debug banner in the main `MaterialApp` by setting
`debugShowCheckedModeBanner` to `false`.

This improves the visual appearance of the app in debug mode and does
not affect the app’s logic or behavior.

