### PR TITLE
Feat: Add configurable rest timer to gym mode

### DIFF
--- a/ios/Flutter/ephemeral/flutter_lldb_helper.py
+++ b/ios/Flutter/ephemeral/flutter_lldb_helper.py
@@ -1,0 +1,32 @@
+#
+# Generated file, do not edit.
+#
+
+import lldb
+
+def handle_new_rx_page(frame: lldb.SBFrame, bp_loc, extra_args, intern_dict):
+    """Intercept NOTIFY_DEBUGGER_ABOUT_RX_PAGES and touch the pages."""
+    base = frame.register["x0"].GetValueAsAddress()
+    page_len = frame.register["x1"].GetValueAsUnsigned()
+
+    # Note: NOTIFY_DEBUGGER_ABOUT_RX_PAGES will check contents of the
+    # first page to see if handled it correctly. This makes diagnosing
+    # misconfiguration (e.g. missing breakpoint) easier.
+    data = bytearray(page_len)
+    data[0:8] = b'IHELPED!'
+
+    error = lldb.SBError()
+    frame.GetThread().GetProcess().WriteMemory(base, data, error)
+    if not error.Success():
+        print(f'Failed to write into {base}[+{page_len}]', error)
+        return
+
+def __lldb_init_module(debugger: lldb.SBDebugger, _):
+    target = debugger.GetDummyTarget()
+    # Caveat: must use BreakpointCreateByRegEx here and not
+    # BreakpointCreateByName. For some reasons callback function does not
+    # get carried over from dummy target for the later.
+    bp = target.BreakpointCreateByRegex("^NOTIFY_DEBUGGER_ABOUT_RX_PAGES$")
+    bp.SetScriptCallbackFunction('{}.handle_new_rx_page'.format(__name__))
+    bp.SetAutoContinue(True)
+    print("-- LLDB integration loaded --")

--- a/ios/Flutter/ephemeral/flutter_lldbinit
+++ b/ios/Flutter/ephemeral/flutter_lldbinit
@@ -1,0 +1,5 @@
+#
+# Generated file, do not edit.
+#
+
+command script import --relative-to-command-file flutter_lldb_helper.py

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -464,6 +464,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.32"
+  flutter_ringtone_player:
+    dependency: "direct main"
+    description:
+      name: flutter_ringtone_player
+      sha256: "0b036416fda0654da52221989bd1a8ccd2876cea57f61ecc3a4fc272bd738c67"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.0"
   flutter_riverpod:
     dependency: "direct main"
     description:
@@ -1523,4 +1531,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.9.0 <4.0.0"
-  flutter: ">=3.35.0"
+  flutter: ">=3.38.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -68,6 +68,8 @@ dependencies:
   video_player: ^2.10.0
   logging: ^1.3.0
   flutter_riverpod: ^2.6.1
+  flutter_ringtone_player: ^3.2.0
+
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Proposed Changes
Added a configurable Rest Timer that appears automatically after saving a set in Gym Mode.

Implemented a toggle between Countdown (timer) and Stopwatch mode directly within the timer dialog.

Added +/- buttons to adjust the rest duration on the fly; the last used duration and mode are saved persistently via shared_preferences.

Added sound notification (beep) when the countdown finishes using audioplayers (works on Windows & Mobile).

Related Issue(s)
Closes # (If you created an issue earlier, put the number here, e.g. #123)

Please check that the PR fulfills these requirements
 Tests for the changes have been added (manual testing done)

 Set a 100 character limit in your editor/IDE to avoid white space diffs in the PR

 Updated/added relevant documentation (doc comments with ///).

 Added relevant reviewers.

Note to Maintainers
I am new to Flutter development and still learning, so I would appreciate any feedback on the code structure or implementation!

Also, I am not 100% satisfied with the UI/UX yet (e.g. the fullscreen dialog styling could be improved to match the app theme better), but the core functionality works as intended. Happy to refine it based on your suggestions.