### PR TITLE
Fix: Add missing trailing slashes for API calls (#1071)

### DIFF
--- a/lib/providers/exercises.dart
+++ b/lib/providers/exercises.dart
@@ -47,14 +47,14 @@ class ExercisesProvider with ChangeNotifier {
   static const EXERCISE_CACHE_DAYS = 7;
   static const CACHE_VERSION = 4;
 
-  static const exerciseUrlPath = 'exercise';
-  static const exerciseInfoUrlPath = 'exerciseinfo';
-  static const exerciseSearchPath = 'exercise/search';
+  static const exerciseUrlPath = 'exercise/';
+  static const exerciseInfoUrlPath = 'exerciseinfo/';
+  static const exerciseSearchPath = 'exercise/search/';
+  static const categoriesUrlPath = 'exercisecategory/';
+  static const musclesUrlPath = 'muscle/';
+  static const equipmentUrlPath = 'equipment/';
+  static const languageUrlPath = 'language/';
 
-  static const categoriesUrlPath = 'exercisecategory';
-  static const musclesUrlPath = 'muscle';
-  static const equipmentUrlPath = 'equipment';
-  static const languageUrlPath = 'language';
 
   List<Exercise> exercises = [];
 


### PR DESCRIPTION
# Proposed Changes
Add missing trailing slashes to API endpoint paths in lib/providers/exercises.dart to prevent 301 redirects on Synology NAS servers.

The affected endpoints are:
- exerciseSearchPath
- categoriesUrlPath  
- musclesUrlPath
- equipmentUrlPath
- languageUrlPath
I will continue to test the software and see if there are any other bugs of this kind.
