### PR TITLE
BUGFIX: unfocus while typing in gym_mode form

### DIFF
--- a/lib/widgets/routines/gym_mode/log_page.dart
+++ b/lib/widgets/routines/gym_mode/log_page.dart
@@ -251,7 +251,7 @@ class LogsRepsWidget extends ConsumerWidget {
           child: TextFormField(
             decoration: InputDecoration(labelText: i18n.repetitions),
             enabled: true,
-            key: ValueKey('reps-field-$repText'),
+            key: const ValueKey('reps-field'),
             initialValue: repText,
             keyboardType: textInputTypeDecimal,
             onChanged: (value) {
@@ -332,7 +332,7 @@ class LogsWeightWidget extends ConsumerWidget {
         // Text field
         Expanded(
           child: TextFormField(
-            key: ValueKey('weight-field-$weightText'),
+            key: const ValueKey('weight-field'),
             decoration: InputDecoration(labelText: i18n.weight),
             initialValue: weightText,
             keyboardType: textInputTypeDecimal,


### PR DESCRIPTION
The Problem:
- User clicks on a the input with a key `Rep-Input-12KG`
- User enters a value `5`
- Since its a stateful widget, a new input is created (i think) with a key `Rep-Input-125KG`
- Previous build doesn't know where `Rep-Input12KG` is, so it drops its focus

I'm still new to flutter, so I'll probably try to write tests next week or so 

# Proposed Changes
- Change Flutter key values to static values

## Related Issue(s)
 Closes #1090 

## Please check that the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Set a 100 character limit in your editor/IDE to avoid white space diffs in the PR
  (run `dart format .`)
- [ ] Updated/added relevant documentation (doc comments with `///`).
- [ ] Added relevant reviewers.
