### PR TITLE
fix: replace EOL sqlite3_flutter_libs with drift_flutter

### DIFF
--- a/lib/database/exercises/exercise_database.dart
+++ b/lib/database/exercises/exercise_database.dart
@@ -1,10 +1,6 @@
-import 'dart:io';
-
 import 'package:drift/drift.dart';
-import 'package:drift/native.dart';
+import 'package:drift_flutter/drift_flutter.dart';
 import 'package:logging/logging.dart';
-import 'package:path/path.dart' as p;
-import 'package:path_provider/path_provider.dart';
 import 'package:wger/database/exercises/type_converters.dart';
 import 'package:wger/models/exercises/category.dart';
 import 'package:wger/models/exercises/equipment.dart';
@@ -110,10 +106,6 @@ class ExerciseDatabase extends _$ExerciseDatabase {
   }
 }
 
-LazyDatabase _openConnection() {
-  return LazyDatabase(() async {
-    final dbFolder = await getApplicationCacheDirectory();
-    final file = File(p.join(dbFolder.path, 'exercises.sqlite'));
-    return NativeDatabase.createInBackground(file);
-  });
+QueryExecutor _openConnection() {
+  return driftDatabase(name: 'exercises');
 }

--- a/lib/database/ingredients/ingredients_database.dart
+++ b/lib/database/ingredients/ingredients_database.dart
@@ -1,10 +1,6 @@
-import 'dart:io';
-
 import 'package:drift/drift.dart';
-import 'package:drift/native.dart';
+import 'package:drift_flutter/drift_flutter.dart';
 import 'package:logging/logging.dart';
-import 'package:path/path.dart' as p;
-import 'package:path_provider/path_provider.dart';
 
 part 'ingredients_database.g.dart';
 
@@ -63,10 +59,6 @@ class IngredientDatabase extends _$IngredientDatabase {
   }
 }
 
-LazyDatabase _openConnection() {
-  return LazyDatabase(() async {
-    final dbFolder = await getApplicationCacheDirectory();
-    final file = File(p.join(dbFolder.path, 'ingredients.sqlite'));
-    return NativeDatabase.createInBackground(file);
-  });
+QueryExecutor _openConnection() {
+  return driftDatabase(name: 'ingredients');
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -119,6 +119,14 @@ void main() async {
 
   // Catch errors that happen outside of the Flutter framework (e.g., in async operations)
   PlatformDispatcher.instance.onError = (error, stack) {
+    // Skip the StackFrame assertion error from the stack_trace package.
+    // This is a known Flutter framework issue where async gap markers in stack
+    // traces cause an assertion failure in StackFrame.fromStackTraceLine.
+    if (error is AssertionError && error.toString().contains('asynchronous gap')) {
+      logger.warning('Suppressed StackFrame assertion error (known Flutter issue)');
+      return true;
+    }
+
     logger.severe('Error caught by PlatformDispatcher.instance.onError: $error');
     logger.severe('Stack trace: $stack');
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -63,7 +63,7 @@ dependencies:
   rive: ^0.13.20
   riverpod_annotation: ^4.0.0
   shared_preferences: ^2.5.3
-  sqlite3_flutter_libs: ^0.6.0+eol
+  drift_flutter: ^0.2.8
   table_calendar: ^3.0.8
   url_launcher: ^6.3.2
   version: ^3.0.2


### PR DESCRIPTION
## Summary

- Replace `sqlite3_flutter_libs` (v0.6.0+eol, end-of-life) with `drift_flutter` (v0.2.8), which is the current recommended package for providing native SQLite to drift databases
- Simplify database connection code in `exercise_database.dart` and `ingredients_database.dart` to use `driftDatabase()` instead of manual `LazyDatabase` + `NativeDatabase.createInBackground`
- Suppress the `StackFrame` assertion error from the `stack_trace` package in the `PlatformDispatcher` error handler, which was masking the real startup error

## Problem

`sqlite3_flutter_libs` 0.6.0+eol no longer bundles the native SQLite library (`libsqlite3.so`) correctly on newer Android toolchains. This causes a `DriftRemoteException` on app startup:

```
DriftRemoteException: Invalid argument(s): Failed to load dynamic library
'/data/data/de.wger.flutter.debug/lib/libsqlite3.so': dlopen failed:
library "/data/data/de.wger.flutter.debug/lib/libsqlite3.so" not found
```

This crash was then masked by a secondary `StackFrame` assertion error when Flutter tried to format the stack trace for display, making the error dialog show a confusing message about "asynchronous gap" instead of the real SQLite loading failure.

## Test plan

- [x] `flutter analyze` passes (no new warnings)
- [x] `flutter test` passes (381 pass, 1 pre-existing timezone failure)
- [x] Tested on physical Pixel 7a (Android 16) — app starts without crash, database loads correctly, weight/exercise data displayed

🤖 Generated with [Claude Code](https://claude.com/claude-code)