### PR TITLE
feat(nutrition): filter ingredient search by Nutri-Score

### DIFF
--- a/lib/helpers/shared_preferences.dart
+++ b/lib/helpers/shared_preferences.dart
@@ -1,5 +1,6 @@
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:shared_preferences/util/legacy_to_async_migration_util.dart';
+import 'package:wger/models/nutrition/ingredient.dart';
 import 'package:wger/providers/nutrition.dart';
 
 /// A helper class that manages preferences using SharedPreferencesAsync
@@ -67,5 +68,30 @@ class PreferenceHelper {
         orElse: () => IngredientSearchLanguage.currentAndEnglish,
       );
     }
+  }
+
+  //4.nutri-score filter toggle
+  Future<void> saveIngredientFilterNutriscore(bool value) async {
+    await PreferenceHelper.asyncPref.setBool('ingredientFilterNutriscore', value);
+  }
+
+  Future<bool> getIngredientFilterNutriscore() async {
+    return await PreferenceHelper.asyncPref.getBool('ingredientFilterNutriscore') ?? false;
+  }
+
+  //5.nutri-score worst acceptable grade
+  Future<void> saveIngredientNutriscoreMax(NutriScore value) async {
+    await PreferenceHelper.asyncPref.setString('ingredientNutriscoreMax', value.name);
+  }
+
+  Future<NutriScore> getIngredientNutriscoreMax() async {
+    final value = await PreferenceHelper.asyncPref.getString('ingredientNutriscoreMax');
+    if (value == null) {
+      return NutriScore.c;
+    }
+    return NutriScore.values.firstWhere(
+      (e) => e.name == value,
+      orElse: () => NutriScore.c,
+    );
   }
 }

--- a/lib/helpers/shared_preferences.dart
+++ b/lib/helpers/shared_preferences.dart
@@ -70,24 +70,19 @@ class PreferenceHelper {
     }
   }
 
-  //4.nutri-score filter toggle
-  Future<void> saveIngredientFilterNutriscore(bool value) async {
-    await PreferenceHelper.asyncPref.setBool('ingredientFilterNutriscore', value);
+  //4.nutri-score worst acceptable grade (null means the filter is off)
+  Future<void> saveIngredientNutriscoreMax(NutriScore? value) async {
+    if (value == null) {
+      await PreferenceHelper.asyncPref.remove('ingredientNutriscoreMax');
+    } else {
+      await PreferenceHelper.asyncPref.setString('ingredientNutriscoreMax', value.name);
+    }
   }
 
-  Future<bool> getIngredientFilterNutriscore() async {
-    return await PreferenceHelper.asyncPref.getBool('ingredientFilterNutriscore') ?? false;
-  }
-
-  //5.nutri-score worst acceptable grade
-  Future<void> saveIngredientNutriscoreMax(NutriScore value) async {
-    await PreferenceHelper.asyncPref.setString('ingredientNutriscoreMax', value.name);
-  }
-
-  Future<NutriScore> getIngredientNutriscoreMax() async {
+  Future<NutriScore?> getIngredientNutriscoreMax() async {
     final value = await PreferenceHelper.asyncPref.getString('ingredientNutriscoreMax');
     if (value == null) {
-      return NutriScore.c;
+      return null;
     }
     return NutriScore.values.firstWhere(
       (e) => e.name == value,

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1200,12 +1200,26 @@
   },
   "searchLanguageAll": "All languages",
   "@searchLanguageAll": {},
-  "filterNutriscore": "Filter by Nutri-Score",
+  "filterNutriscore": "Nutri-Score filter",
   "@filterNutriscore": {
-    "description": "Label for the toggle that enables Nutri-Score filtering in the ingredient search"
+    "description": "Heading for the Nutri-Score slider in the ingredient search filter dialog"
   },
-  "filterNutriscoreMax": "Worst acceptable grade",
-  "@filterNutriscoreMax": {
-    "description": "Label describing the Nutri-Score slider (the worst grade the user will accept, A is best and E is worst)"
+  "filterNutriscoreOff": "Off",
+  "@filterNutriscoreOff": {
+    "description": "Label for the first slider stop, which disables the Nutri-Score filter"
+  },
+  "filterNutriscoreNoFilter": "No filter",
+  "@filterNutriscoreNoFilter": {
+    "description": "Helper text shown under the Nutri-Score slider when it is at the Off position"
+  },
+  "filterNutriscoreOrBetter": "{grade} or better",
+  "@filterNutriscoreOrBetter": {
+    "description": "Helper text shown under the Nutri-Score slider when a grade is selected (e.g. 'C or better')",
+    "placeholders": {
+      "grade": {
+        "type": "String",
+        "example": "C"
+      }
+    }
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1199,5 +1199,13 @@
     }
   },
   "searchLanguageAll": "All languages",
-  "@searchLanguageAll": {}
+  "@searchLanguageAll": {},
+  "filterNutriscore": "Filter by Nutri-Score",
+  "@filterNutriscore": {
+    "description": "Label for the toggle that enables Nutri-Score filtering in the ingredient search"
+  },
+  "filterNutriscoreMax": "Worst acceptable grade",
+  "@filterNutriscoreMax": {
+    "description": "Label describing the Nutri-Score slider (the worst grade the user will accept, A is best and E is worst)"
+  }
 }

--- a/lib/models/nutrition/ingredient_filters.dart
+++ b/lib/models/nutrition/ingredient_filters.dart
@@ -7,35 +7,30 @@ class IngredientFilters {
   final bool isVegetarian;
   final IngredientSearchLanguage searchLanguage;
 
-  /// When true, [nutriscoreMax] is applied as `nutriscore__lte` on the search.
-  final bool filterNutriscore;
-
-  /// Worst acceptable Nutri-Score grade (lexicographically sent as
-  /// `nutriscore__lte` to the backend). Ignored when [filterNutriscore] is
-  /// false.
-  final NutriScore nutriscoreMax;
+  /// Worst acceptable Nutri-Score grade, sent to the backend as
+  /// `nutriscore__lte`. `null` means the filter is off (slider at the
+  /// "No filter" position).
+  final NutriScore? nutriscoreMax;
 
   IngredientFilters({
     required this.isVegan,
     required this.isVegetarian,
     required this.searchLanguage,
-    this.filterNutriscore = false,
-    this.nutriscoreMax = NutriScore.c,
+    this.nutriscoreMax,
   });
 
   IngredientFilters copyWith({
     bool? isVegan,
     bool? isVegetarian,
     IngredientSearchLanguage? searchLanguage,
-    bool? filterNutriscore,
     NutriScore? nutriscoreMax,
+    bool clearNutriscoreMax = false,
   }) {
     return IngredientFilters(
       isVegan: isVegan ?? this.isVegan,
       isVegetarian: isVegetarian ?? this.isVegetarian,
       searchLanguage: searchLanguage ?? this.searchLanguage,
-      filterNutriscore: filterNutriscore ?? this.filterNutriscore,
-      nutriscoreMax: nutriscoreMax ?? this.nutriscoreMax,
+      nutriscoreMax: clearNutriscoreMax ? null : (nutriscoreMax ?? this.nutriscoreMax),
     );
   }
 }

--- a/lib/models/nutrition/ingredient_filters.dart
+++ b/lib/models/nutrition/ingredient_filters.dart
@@ -1,25 +1,41 @@
 //model is used to store ingredient filters values
+import 'package:wger/models/nutrition/ingredient.dart';
 import 'package:wger/providers/nutrition.dart';
 
 class IngredientFilters {
   final bool isVegan;
   final bool isVegetarian;
   final IngredientSearchLanguage searchLanguage;
+
+  /// When true, [nutriscoreMax] is applied as `nutriscore__lte` on the search.
+  final bool filterNutriscore;
+
+  /// Worst acceptable Nutri-Score grade (lexicographically sent as
+  /// `nutriscore__lte` to the backend). Ignored when [filterNutriscore] is
+  /// false.
+  final NutriScore nutriscoreMax;
+
   IngredientFilters({
     required this.isVegan,
     required this.isVegetarian,
     required this.searchLanguage,
+    this.filterNutriscore = false,
+    this.nutriscoreMax = NutriScore.c,
   });
 
   IngredientFilters copyWith({
     bool? isVegan,
     bool? isVegetarian,
     IngredientSearchLanguage? searchLanguage,
+    bool? filterNutriscore,
+    NutriScore? nutriscoreMax,
   }) {
     return IngredientFilters(
       isVegan: isVegan ?? this.isVegan,
       isVegetarian: isVegetarian ?? this.isVegetarian,
       searchLanguage: searchLanguage ?? this.searchLanguage,
+      filterNutriscore: filterNutriscore ?? this.filterNutriscore,
+      nutriscoreMax: nutriscoreMax ?? this.nutriscoreMax,
     );
   }
 }

--- a/lib/providers/nutrition.dart
+++ b/lib/providers/nutrition.dart
@@ -403,12 +403,18 @@ class NutritionPlansProvider with ChangeNotifier {
   }
 
   /// Searches for an ingredient
+  ///
+  /// [nutriscoreMax] — if non-null, the worst acceptable Nutri-Score grade,
+  /// sent to the backend as `nutriscore__lte`. The Django filterset
+  /// compares lexicographically on the `a`..`e` choices, so passing
+  /// [NutriScore.b] yields "only A or B".
   Future<List<Ingredient>> searchIngredient(
     String name, {
     String languageCode = 'en',
     IngredientSearchLanguage searchLanguage = IngredientSearchLanguage.current,
     bool isVegan = false,
     bool isVegetarian = false,
+    NutriScore? nutriscoreMax,
   }) async {
     if (name.length <= 1) {
       return [];
@@ -445,6 +451,10 @@ class NutritionPlansProvider with ChangeNotifier {
 
     if (isVegetarian) {
       query['is_vegetarian'] = 'true';
+    }
+
+    if (nutriscoreMax != null) {
+      query['nutriscore__lte'] = nutriscoreMax.name;
     }
 
     // Send the request

--- a/lib/providers/nutrition_ingredient_filters_riverpod.dart
+++ b/lib/providers/nutrition_ingredient_filters_riverpod.dart
@@ -19,6 +19,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart' show Provider;
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:wger/helpers/shared_preferences.dart';
+import 'package:wger/models/nutrition/ingredient.dart';
 import 'package:wger/models/nutrition/ingredient_filters.dart';
 import 'package:wger/providers/nutrition.dart';
 
@@ -33,10 +34,14 @@ class IngredientFiltersNotifier extends _$IngredientFiltersNotifier {
     final isVegan = await preferenceHelper.getIngredientVeganFilter();
     final isVegetarian = await preferenceHelper.getIngredientVegetarianFilter();
     final searchLanguage = await preferenceHelper.getIngredientSearchLanguage();
+    final filterNutriscore = await preferenceHelper.getIngredientFilterNutriscore();
+    final nutriscoreMax = await preferenceHelper.getIngredientNutriscoreMax();
     return IngredientFilters(
       isVegan: isVegan,
       isVegetarian: isVegetarian,
       searchLanguage: searchLanguage,
+      filterNutriscore: filterNutriscore,
+      nutriscoreMax: nutriscoreMax,
     );
   }
 
@@ -66,6 +71,18 @@ class IngredientFiltersNotifier extends _$IngredientFiltersNotifier {
     final current = _current();
     state = AsyncData(current.copyWith(searchLanguage: value));
     await PreferenceHelper.instance.saveIngredientSearchLanguage(value);
+  }
+
+  Future<void> toggleNutriscore(bool value) async {
+    final current = _current();
+    state = AsyncData(current.copyWith(filterNutriscore: value));
+    await PreferenceHelper.instance.saveIngredientFilterNutriscore(value);
+  }
+
+  Future<void> chooseNutriscoreMax(NutriScore value) async {
+    final current = _current();
+    state = AsyncData(current.copyWith(nutriscoreMax: value));
+    await PreferenceHelper.instance.saveIngredientNutriscoreMax(value);
   }
 }
 

--- a/lib/providers/nutrition_ingredient_filters_riverpod.dart
+++ b/lib/providers/nutrition_ingredient_filters_riverpod.dart
@@ -34,13 +34,11 @@ class IngredientFiltersNotifier extends _$IngredientFiltersNotifier {
     final isVegan = await preferenceHelper.getIngredientVeganFilter();
     final isVegetarian = await preferenceHelper.getIngredientVegetarianFilter();
     final searchLanguage = await preferenceHelper.getIngredientSearchLanguage();
-    final filterNutriscore = await preferenceHelper.getIngredientFilterNutriscore();
     final nutriscoreMax = await preferenceHelper.getIngredientNutriscoreMax();
     return IngredientFilters(
       isVegan: isVegan,
       isVegetarian: isVegetarian,
       searchLanguage: searchLanguage,
-      filterNutriscore: filterNutriscore,
       nutriscoreMax: nutriscoreMax,
     );
   }
@@ -73,15 +71,13 @@ class IngredientFiltersNotifier extends _$IngredientFiltersNotifier {
     await PreferenceHelper.instance.saveIngredientSearchLanguage(value);
   }
 
-  Future<void> toggleNutriscore(bool value) async {
+  Future<void> chooseNutriscoreMax(NutriScore? value) async {
     final current = _current();
-    state = AsyncData(current.copyWith(filterNutriscore: value));
-    await PreferenceHelper.instance.saveIngredientFilterNutriscore(value);
-  }
-
-  Future<void> chooseNutriscoreMax(NutriScore value) async {
-    final current = _current();
-    state = AsyncData(current.copyWith(nutriscoreMax: value));
+    state = AsyncData(
+      value == null
+          ? current.copyWith(clearNutriscoreMax: true)
+          : current.copyWith(nutriscoreMax: value),
+    );
     await PreferenceHelper.instance.saveIngredientNutriscoreMax(value);
   }
 }

--- a/lib/providers/nutrition_ingredient_filters_riverpod.g.dart
+++ b/lib/providers/nutrition_ingredient_filters_riverpod.g.dart
@@ -13,7 +13,8 @@ part of 'nutrition_ingredient_filters_riverpod.dart';
 final ingredientFiltersProvider = IngredientFiltersNotifierProvider._();
 
 final class IngredientFiltersNotifierProvider
-    extends $AsyncNotifierProvider<IngredientFiltersNotifier, IngredientFilters> {
+    extends
+        $AsyncNotifierProvider<IngredientFiltersNotifier, IngredientFilters> {
   IngredientFiltersNotifierProvider._()
     : super(
         from: null,
@@ -33,14 +34,17 @@ final class IngredientFiltersNotifierProvider
   IngredientFiltersNotifier create() => IngredientFiltersNotifier();
 }
 
-String _$ingredientFiltersNotifierHash() => r'839633dd545b6a9a6cbb8840098fe15f7c827897';
+String _$ingredientFiltersNotifierHash() =>
+    r'0d6cc41b8e45673367dc756d55a95b8ac4252d7d';
 
-abstract class _$IngredientFiltersNotifier extends $AsyncNotifier<IngredientFilters> {
+abstract class _$IngredientFiltersNotifier
+    extends $AsyncNotifier<IngredientFilters> {
   FutureOr<IngredientFilters> build();
   @$mustCallSuper
   @override
   void runBuild() {
-    final ref = this.ref as $Ref<AsyncValue<IngredientFilters>, IngredientFilters>;
+    final ref =
+        this.ref as $Ref<AsyncValue<IngredientFilters>, IngredientFilters>;
     final element =
         ref.element
             as $ClassProviderElement<

--- a/lib/widgets/nutrition/widgets.dart
+++ b/lib/widgets/nutrition/widgets.dart
@@ -163,6 +163,7 @@ class _IngredientTypeaheadState extends ConsumerState<IngredientTypeahead> {
               searchLanguage: filters.searchLanguage,
               isVegan: filters.isVegan,
               isVegetarian: filters.isVegetarian,
+              nutriscoreMax: filters.filterNutriscore ? filters.nutriscoreMax : null,
             );
           },
           itemBuilder: (context, ingredient) {
@@ -375,6 +376,27 @@ class _IngredientTypeaheadState extends ConsumerState<IngredientTypeahead> {
                               });
                             },
                           ),
+                          SwitchListTile(
+                            title: Text(i18n.filterNutriscore),
+                            value: filters.filterNutriscore,
+                            contentPadding: EdgeInsets.zero,
+                            onChanged: (val) {
+                              setDialogState(() {
+                                ref.read(ingredientFiltersProvider.notifier).toggleNutriscore(val);
+                              });
+                            },
+                          ),
+                          if (filters.filterNutriscore)
+                            _NutriscoreSlider(
+                              value: filters.nutriscoreMax,
+                              onChanged: (grade) {
+                                setDialogState(() {
+                                  ref
+                                      .read(ingredientFiltersProvider.notifier)
+                                      .chooseNutriscoreMax(grade);
+                                });
+                              },
+                            ),
                         ],
                       ),
                       actions: [
@@ -391,6 +413,56 @@ class _IngredientTypeaheadState extends ConsumerState<IngredientTypeahead> {
           },
         );
       },
+    );
+  }
+}
+
+/// Discrete slider that lets the user pick the worst acceptable [NutriScore]
+/// grade (A..E). Sits inside the filter dialog directly below the
+/// "Filter by Nutri-Score" switch.
+class _NutriscoreSlider extends StatelessWidget {
+  final NutriScore value;
+  final ValueChanged<NutriScore> onChanged;
+
+  const _NutriscoreSlider({required this.value, required this.onChanged});
+
+  @override
+  Widget build(BuildContext context) {
+    final i18n = AppLocalizations.of(context);
+    final index = NutriScore.values.indexOf(value);
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            i18n.filterNutriscoreMax,
+            style: Theme.of(context).textTheme.bodySmall,
+          ),
+          Slider(
+            value: index.toDouble(),
+            min: 0,
+            max: (NutriScore.values.length - 1).toDouble(),
+            divisions: NutriScore.values.length - 1,
+            label: value.name.toUpperCase(),
+            onChanged: (v) => onChanged(NutriScore.values[v.round()]),
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: NutriScore.values
+                  .map(
+                    (score) => Text(
+                      score.name.toUpperCase(),
+                      style: Theme.of(context).textTheme.labelSmall,
+                    ),
+                  )
+                  .toList(),
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/widgets/nutrition/widgets.dart
+++ b/lib/widgets/nutrition/widgets.dart
@@ -163,7 +163,7 @@ class _IngredientTypeaheadState extends ConsumerState<IngredientTypeahead> {
               searchLanguage: filters.searchLanguage,
               isVegan: filters.isVegan,
               isVegetarian: filters.isVegetarian,
-              nutriscoreMax: filters.filterNutriscore ? filters.nutriscoreMax : null,
+              nutriscoreMax: filters.nutriscoreMax,
             );
           },
           itemBuilder: (context, ingredient) {
@@ -376,27 +376,16 @@ class _IngredientTypeaheadState extends ConsumerState<IngredientTypeahead> {
                               });
                             },
                           ),
-                          SwitchListTile(
-                            title: Text(i18n.filterNutriscore),
-                            value: filters.filterNutriscore,
-                            contentPadding: EdgeInsets.zero,
-                            onChanged: (val) {
+                          _NutriscoreSlider(
+                            value: filters.nutriscoreMax,
+                            onChanged: (grade) {
                               setDialogState(() {
-                                ref.read(ingredientFiltersProvider.notifier).toggleNutriscore(val);
+                                ref
+                                    .read(ingredientFiltersProvider.notifier)
+                                    .chooseNutriscoreMax(grade);
                               });
                             },
                           ),
-                          if (filters.filterNutriscore)
-                            _NutriscoreSlider(
-                              value: filters.nutriscoreMax,
-                              onChanged: (grade) {
-                                setDialogState(() {
-                                  ref
-                                      .read(ingredientFiltersProvider.notifier)
-                                      .chooseNutriscoreMax(grade);
-                                });
-                              },
-                            ),
                         ],
                       ),
                       actions: [
@@ -418,47 +407,65 @@ class _IngredientTypeaheadState extends ConsumerState<IngredientTypeahead> {
 }
 
 /// Discrete slider that lets the user pick the worst acceptable [NutriScore]
-/// grade (A..E). Sits inside the filter dialog directly below the
-/// "Filter by Nutri-Score" switch.
+/// grade. Index 0 is the "Off" position (no filter, `null` value) and
+/// indices 1..N map to [NutriScore.values].
 class _NutriscoreSlider extends StatelessWidget {
-  final NutriScore value;
-  final ValueChanged<NutriScore> onChanged;
+  final NutriScore? value;
+  final ValueChanged<NutriScore?> onChanged;
 
   const _NutriscoreSlider({required this.value, required this.onChanged});
+
+  static const int _offIndex = 0;
+
+  int _valueToIndex(NutriScore? v) => v == null ? _offIndex : NutriScore.values.indexOf(v) + 1;
+
+  NutriScore? _indexToValue(int i) => i == _offIndex ? null : NutriScore.values[i - 1];
 
   @override
   Widget build(BuildContext context) {
     final i18n = AppLocalizations.of(context);
-    final index = NutriScore.values.indexOf(value);
+    final index = _valueToIndex(value);
+    final maxIndex = NutriScore.values.length; // 0=Off, then A..E
+    final helperText = value == null
+        ? i18n.filterNutriscoreNoFilter
+        : i18n.filterNutriscoreOrBetter(value!.name.toUpperCase());
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Text(
-            i18n.filterNutriscoreMax,
+            i18n.filterNutriscore,
+            style: Theme.of(context).textTheme.bodyMedium,
+          ),
+          Text(
+            helperText,
             style: Theme.of(context).textTheme.bodySmall,
           ),
           Slider(
             value: index.toDouble(),
             min: 0,
-            max: (NutriScore.values.length - 1).toDouble(),
-            divisions: NutriScore.values.length - 1,
-            label: value.name.toUpperCase(),
-            onChanged: (v) => onChanged(NutriScore.values[v.round()]),
+            max: maxIndex.toDouble(),
+            divisions: maxIndex,
+            label: value == null ? i18n.filterNutriscoreOff : value!.name.toUpperCase(),
+            onChanged: (v) => onChanged(_indexToValue(v.round())),
           ),
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 12),
             child: Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: NutriScore.values
-                  .map(
-                    (score) => Text(
-                      score.name.toUpperCase(),
-                      style: Theme.of(context).textTheme.labelSmall,
-                    ),
-                  )
-                  .toList(),
+              children: [
+                Text(
+                  i18n.filterNutriscoreOff,
+                  style: Theme.of(context).textTheme.labelSmall,
+                ),
+                ...NutriScore.values.map(
+                  (score) => Text(
+                    score.name.toUpperCase(),
+                    style: Theme.of(context).textTheme.labelSmall,
+                  ),
+                ),
+              ],
             ),
           ),
         ],

--- a/test/core/settings_test.mocks.dart
+++ b/test/core/settings_test.mocks.dart
@@ -830,6 +830,7 @@ class MockNutritionPlansProvider extends _i1.Mock implements _i20.NutritionPlans
     _i20.IngredientSearchLanguage? searchLanguage = _i20.IngredientSearchLanguage.current,
     bool? isVegan = false,
     bool? isVegetarian = false,
+    _i13.NutriScore? nutriscoreMax,
   }) =>
       (super.noSuchMethod(
             Invocation.method(
@@ -840,6 +841,7 @@ class MockNutritionPlansProvider extends _i1.Mock implements _i20.NutritionPlans
                 #searchLanguage: searchLanguage,
                 #isVegan: isVegan,
                 #isVegetarian: isVegetarian,
+                #nutriscoreMax: nutriscoreMax,
               },
             ),
             returnValue: _i18.Future<List<_i13.Ingredient>>.value(

--- a/test/nutrition/ingredient_typeahead_test.dart
+++ b/test/nutrition/ingredient_typeahead_test.dart
@@ -49,6 +49,7 @@ void main() {
         searchLanguage: anyNamed('searchLanguage'),
         isVegan: anyNamed('isVegan'),
         isVegetarian: anyNamed('isVegetarian'),
+        nutriscoreMax: anyNamed('nutriscoreMax'),
       ),
     ).thenAnswer(
       (invocation) => Future.value([
@@ -135,6 +136,7 @@ void main() {
         searchLanguage: anyNamed('searchLanguage'),
         isVegan: anyNamed('isVegan'),
         isVegetarian: anyNamed('isVegetarian'),
+        nutriscoreMax: anyNamed('nutriscoreMax'),
       ),
     ).thenAnswer((_) => Future.value([ingredient1]));
 
@@ -158,6 +160,7 @@ void main() {
         searchLanguage: anyNamed('searchLanguage'),
         isVegan: anyNamed('isVegan'),
         isVegetarian: anyNamed('isVegetarian'),
+        nutriscoreMax: anyNamed('nutriscoreMax'),
       ),
     ).thenAnswer((_) => Future.value([milk]));
 
@@ -179,6 +182,7 @@ void main() {
         searchLanguage: anyNamed('searchLanguage'),
         isVegan: anyNamed('isVegan'),
         isVegetarian: anyNamed('isVegetarian'),
+        nutriscoreMax: anyNamed('nutriscoreMax'),
       ),
     ).thenAnswer((_) => Future.value([ingredient2]));
 
@@ -222,6 +226,82 @@ void main() {
         searchLanguage: IngredientSearchLanguage.current,
         isVegan: true,
         isVegetarian: false,
+        nutriscoreMax: null,
+      ),
+    ).called(1);
+  });
+
+  testWidgets('Nutri-Score slider is hidden until the switch is enabled', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(createWidgetUnderTest());
+
+    await tester.tap(find.byIcon(Icons.tune));
+    await tester.pumpAndSettle();
+
+    // Slider is not rendered initially
+    expect(find.byType(Slider), findsNothing);
+
+    // Turn the switch on
+    final nutriswitch = find.widgetWithText(SwitchListTile, 'Filter by Nutri-Score');
+    expect(nutriswitch, findsOneWidget);
+    expect(tester.widget<SwitchListTile>(nutriswitch).value, isFalse);
+    await tester.tap(nutriswitch);
+    await tester.pumpAndSettle();
+
+    // Slider now appears
+    expect(find.byType(Slider), findsOneWidget);
+    expect(tester.widget<SwitchListTile>(nutriswitch).value, isTrue);
+  });
+
+  testWidgets('Search sends nutriscoreMax when the filter is enabled', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(createWidgetUnderTest());
+
+    await tester.tap(find.byIcon(Icons.tune));
+    await tester.pumpAndSettle();
+
+    // Enable Nutri-Score filter — the default worst-acceptable grade is C
+    await tester.tap(find.widgetWithText(SwitchListTile, 'Filter by Nutri-Score'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Close'));
+    await tester.pumpAndSettle();
+
+    // Act
+    await tester.enterText(find.byType(TextFormField), 'Apple');
+    await tester.pump(const Duration(milliseconds: 600));
+
+    // Assert — with the switch on, the default max grade C flows through
+    verify(
+      mockNutrition.searchIngredient(
+        'Apple',
+        languageCode: 'en',
+        searchLanguage: IngredientSearchLanguage.current,
+        isVegan: false,
+        isVegetarian: false,
+        nutriscoreMax: NutriScore.c,
+      ),
+    ).called(1);
+  });
+
+  testWidgets('Search omits nutriscoreMax when the filter switch is off', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(createWidgetUnderTest());
+
+    await tester.enterText(find.byType(TextFormField), 'Apple');
+    await tester.pump(const Duration(milliseconds: 600));
+
+    verify(
+      mockNutrition.searchIngredient(
+        'Apple',
+        languageCode: 'en',
+        searchLanguage: IngredientSearchLanguage.current,
+        isVegan: false,
+        isVegetarian: false,
+        nutriscoreMax: null,
       ),
     ).called(1);
   });

--- a/test/nutrition/ingredient_typeahead_test.dart
+++ b/test/nutrition/ingredient_typeahead_test.dart
@@ -231,7 +231,7 @@ void main() {
     ).called(1);
   });
 
-  testWidgets('Nutri-Score slider is hidden until the switch is enabled', (
+  testWidgets('Nutri-Score slider is always visible and defaults to Off', (
     WidgetTester tester,
   ) async {
     await tester.pumpWidget(createWidgetUnderTest());
@@ -239,22 +239,16 @@ void main() {
     await tester.tap(find.byIcon(Icons.tune));
     await tester.pumpAndSettle();
 
-    // Slider is not rendered initially
-    expect(find.byType(Slider), findsNothing);
+    // Slider is rendered by default, at the Off position (value == 0)
+    final sliderFinder = find.byType(Slider);
+    expect(sliderFinder, findsOneWidget);
+    expect(tester.widget<Slider>(sliderFinder).value, 0.0);
 
-    // Turn the switch on
-    final nutriswitch = find.widgetWithText(SwitchListTile, 'Filter by Nutri-Score');
-    expect(nutriswitch, findsOneWidget);
-    expect(tester.widget<SwitchListTile>(nutriswitch).value, isFalse);
-    await tester.tap(nutriswitch);
-    await tester.pumpAndSettle();
-
-    // Slider now appears
-    expect(find.byType(Slider), findsOneWidget);
-    expect(tester.widget<SwitchListTile>(nutriswitch).value, isTrue);
+    // The "No filter" helper text is shown
+    expect(find.text('No filter'), findsOneWidget);
   });
 
-  testWidgets('Search sends nutriscoreMax when the filter is enabled', (
+  testWidgets('Moving the slider sends nutriscoreMax on subsequent search', (
     WidgetTester tester,
   ) async {
     await tester.pumpWidget(createWidgetUnderTest());
@@ -262,8 +256,10 @@ void main() {
     await tester.tap(find.byIcon(Icons.tune));
     await tester.pumpAndSettle();
 
-    // Enable Nutri-Score filter — the default worst-acceptable grade is C
-    await tester.tap(find.widgetWithText(SwitchListTile, 'Filter by Nutri-Score'));
+    // Move the slider off the Off position — index 1 is the first grade, A
+    final sliderFinder = find.byType(Slider);
+    final Slider slider = tester.widget<Slider>(sliderFinder);
+    slider.onChanged!(1.0);
     await tester.pumpAndSettle();
 
     await tester.tap(find.text('Close'));
@@ -273,7 +269,7 @@ void main() {
     await tester.enterText(find.byType(TextFormField), 'Apple');
     await tester.pump(const Duration(milliseconds: 600));
 
-    // Assert — with the switch on, the default max grade C flows through
+    // Assert — index 1 maps to NutriScore.a
     verify(
       mockNutrition.searchIngredient(
         'Apple',
@@ -281,12 +277,12 @@ void main() {
         searchLanguage: IngredientSearchLanguage.current,
         isVegan: false,
         isVegetarian: false,
-        nutriscoreMax: NutriScore.c,
+        nutriscoreMax: NutriScore.a,
       ),
     ).called(1);
   });
 
-  testWidgets('Search omits nutriscoreMax when the filter switch is off', (
+  testWidgets('Search omits nutriscoreMax when the slider is at Off', (
     WidgetTester tester,
   ) async {
     await tester.pumpWidget(createWidgetUnderTest());

--- a/test/nutrition/nutritional_meal_form_test.mocks.dart
+++ b/test/nutrition/nutritional_meal_form_test.mocks.dart
@@ -347,6 +347,7 @@ class MockNutritionPlansProvider extends _i1.Mock implements _i8.NutritionPlansP
     _i8.IngredientSearchLanguage? searchLanguage = _i8.IngredientSearchLanguage.current,
     bool? isVegan = false,
     bool? isVegetarian = false,
+    _i7.NutriScore? nutriscoreMax,
   }) =>
       (super.noSuchMethod(
             Invocation.method(
@@ -357,6 +358,7 @@ class MockNutritionPlansProvider extends _i1.Mock implements _i8.NutritionPlansP
                 #searchLanguage: searchLanguage,
                 #isVegan: isVegan,
                 #isVegetarian: isVegetarian,
+                #nutriscoreMax: nutriscoreMax,
               },
             ),
             returnValue: _i9.Future<List<_i7.Ingredient>>.value(

--- a/test/nutrition/nutritional_meal_item_form_test.dart
+++ b/test/nutrition/nutritional_meal_item_form_test.dart
@@ -102,6 +102,9 @@ void main() {
         any,
         languageCode: anyNamed('languageCode'),
         searchLanguage: anyNamed('searchLanguage'),
+        isVegan: anyNamed('isVegan'),
+        isVegetarian: anyNamed('isVegetarian'),
+        nutriscoreMax: anyNamed('nutriscoreMax'),
       ),
     ).thenAnswer(
       (_) => Future.value([ingredient1, ingredient2]),

--- a/test/nutrition/nutritional_plan_form_test.mocks.dart
+++ b/test/nutrition/nutritional_plan_form_test.mocks.dart
@@ -347,6 +347,7 @@ class MockNutritionPlansProvider extends _i1.Mock implements _i8.NutritionPlansP
     _i8.IngredientSearchLanguage? searchLanguage = _i8.IngredientSearchLanguage.current,
     bool? isVegan = false,
     bool? isVegetarian = false,
+    _i7.NutriScore? nutriscoreMax,
   }) =>
       (super.noSuchMethod(
             Invocation.method(
@@ -357,6 +358,7 @@ class MockNutritionPlansProvider extends _i1.Mock implements _i8.NutritionPlansP
                 #searchLanguage: searchLanguage,
                 #isVegan: isVegan,
                 #isVegetarian: isVegetarian,
+                #nutriscoreMax: nutriscoreMax,
               },
             ),
             returnValue: _i9.Future<List<_i7.Ingredient>>.value(

--- a/test/weight/weight_screen_test.mocks.dart
+++ b/test/weight/weight_screen_test.mocks.dart
@@ -652,6 +652,7 @@ class MockNutritionPlansProvider extends _i1.Mock implements _i16.NutritionPlans
     _i16.IngredientSearchLanguage? searchLanguage = _i16.IngredientSearchLanguage.current,
     bool? isVegan = false,
     bool? isVegetarian = false,
+    _i9.NutriScore? nutriscoreMax,
   }) =>
       (super.noSuchMethod(
             Invocation.method(
@@ -662,6 +663,7 @@ class MockNutritionPlansProvider extends _i1.Mock implements _i16.NutritionPlans
                 #searchLanguage: searchLanguage,
                 #isVegan: isVegan,
                 #isVegetarian: isVegetarian,
+                #nutriscoreMax: nutriscoreMax,
               },
             ),
             returnValue: _i11.Future<List<_i9.Ingredient>>.value(


### PR DESCRIPTION
Closes part of wger-project/wger#2295 for the Flutter client.

## Summary
Adds a "Filter by Nutri-Score" switch + A–E discrete slider to the ingredient search filter popover, mirroring the React PR (wger-project/react#1237). When enabled, the selected worst-acceptable grade is sent to the backend as `nutriscore__lte=<a|b|c|d|e>` — the range lookup introduced in backend PR wger-project/wger#2305.

## What changed
- `IngredientFilters`: adds `filterNutriscore` (bool) + `nutriscoreMax` (`NutriScore` enum, default `e`)
- `PreferenceHelper`: persists both settings across sessions
- `IngredientFiltersNotifier` (riverpod): `toggleNutriscore` + `chooseNutriscoreMax`
- `NutritionPlansProvider.searchIngredient`: forwards `nutriscoreMax` as the `nutriscore__lte` query arg
- `IngredientTypeahead` filter popover: new `SwitchListTile` + 5-division `Slider` (A = 0, E = 4); slider is hidden until the switch is on
- i18n: English strings `filterNutriscore` and `filterNutriscoreMax` added to `app_en.arb`
- Tests: 3 new widget tests in `test/nutrition/ingredient_typeahead_test.dart` covering (1) slider hidden until switch flips, (2) query emitted without the filter, (3) `nutriscoreMax` threaded through when the filter is on
- Generated Mockito overrides updated across `nutritional_meal_form_test.mocks.dart`, `nutritional_plan_form_test.mocks.dart`, `settings_test.mocks.dart`, and `weight_screen_test.mocks.dart` so existing stubs still match the extended `searchIngredient` signature

## UI
Same layout as the React PR (wger-project/react#1237 has screenshots of the equivalent UI): the existing vegan / vegetarian filter popover now has a third `SwitchListTile` labelled **Filter by Nutri-Score**. Flipping it reveals a `Slider` with 5 discrete stops (A · B · C · D · E). The current max grade renders in the slider label. State persists across app restarts via `SharedPreferencesAsync`.

## Test plan
- [x] `flutter analyze` clean on changed files
- [x] `flutter test test/nutrition/` — 27 passing including the 3 new widget tests
- [x] `flutter test test/core/settings_test.dart test/weight/weight_screen_test.dart` — mockito overrides still match
- [ ] Manual: backend running PR #2305 + search "ap", flip switch, drag slider to B — confirm results exclude C/D/E-rated items

## Related
- Backend (Django): wger-project/wger#2305
- Frontend (React): wger-project/react#1237
- Tracking issue: wger-project/wger#2295