### PR TITLE
fix(routine): resolve in-place state mutation in GymStateNotifier and enable Routine immutability

### DIFF
--- a/lib/models/workouts/routine.dart
+++ b/lib/models/workouts/routine.dart
@@ -122,6 +122,38 @@ class Routine {
 
   Map<String, dynamic> toJson() => _$RoutineToJson(this);
 
+  Routine copyWith({
+    int? id,
+    DateTime? created,
+    String? name,
+    String? description,
+    bool? fitInWeek,
+    bool? isTemplate,
+    bool? isPublic,
+    DateTime? start,
+    DateTime? end,
+    List<Day>? days,
+    List<DayData>? dayData,
+    List<DayData>? dayDataGym,
+    List<WorkoutSession>? sessions,
+  }) {
+    return Routine(
+      id: id ?? this.id,
+      created: created ?? this.created,
+      name: name ?? this.name,
+      description: description ?? this.description,
+      fitInWeek: fitInWeek ?? this.fitInWeek,
+      isTemplate: isTemplate ?? this.isTemplate,
+      isPublic: isPublic ?? this.isPublic,
+      start: start ?? this.start,
+      end: end ?? this.end,
+      days: days ?? this.days,
+      dayData: dayData ?? this.dayData,
+      dayDataGym: dayDataGym ?? this.dayDataGym,
+      sessions: sessions ?? this.sessions,
+    );
+  }
+
   RoutineTableCompanion toCompanion() {
     final routineId = id;
     if (routineId == null) {
@@ -237,8 +269,14 @@ class Routine {
     return groupedLogs;
   }
 
-  void replaceExercise(int oldExerciseId, Exercise newExercise) {
-    for (final session in sessions) {
+  Routine replaceExercise(int oldExerciseId, Exercise newExercise) {
+    final updatedRoutine = this.copyWith(
+      sessions: List<WorkoutSession>.from(this.sessions),
+      dayData: List<DayData>.from(this.dayData),
+      dayDataGym: List<DayData>.from(this.dayDataGym),
+    );
+
+    for (final session in updatedRoutine.sessions) {
       for (final log in session.logs) {
         if (log.exerciseId == oldExerciseId) {
           log.exerciseId = newExercise.id!;
@@ -247,7 +285,7 @@ class Routine {
       }
     }
 
-    for (final day in dayData) {
+    for (final day in updatedRoutine.dayData) {
       for (final slot in day.slots) {
         for (final config in slot.setConfigs) {
           if (config.exerciseId == oldExerciseId) {
@@ -258,7 +296,7 @@ class Routine {
       }
     }
 
-    for (final day in dayDataGym) {
+    for (final day in updatedRoutine.dayDataGym) {
       for (final slot in day.slots) {
         for (final config in slot.setConfigs) {
           if (config.exerciseId == oldExerciseId) {
@@ -268,5 +306,6 @@ class Routine {
         }
       }
     }
+    return updatedRoutine;
   }
 }

--- a/lib/providers/gym_state.dart
+++ b/lib/providers/gym_state.dart
@@ -676,10 +676,11 @@ class GymStateNotifier extends _$GymStateNotifier {
       return page.copyWith(slotPages: updatedSlotPages);
     }).toList();
 
-    // TODO: this should not be done in-place!
-    state.routine.replaceExercise(originalExerciseId, newExercise);
+    // replace and update new immutable routine instance
+    final updatedRoutine = state.routine.replaceExercise(originalExerciseId, newExercise);
     state = state.copyWith(
       pages: updatedPages,
+      routine: updatedRoutine,
     );
     _logger.fine('Replaced exercise $originalExerciseId with ${newExercise.id}');
   }

--- a/lib/widgets/core/image.dart
+++ b/lib/widgets/core/image.dart
@@ -10,23 +10,20 @@ Widget handleImageError(
   StackTrace? stackTrace,
   String imageUrl,
 ) {
-  final imageFormat = imageUrl.split('.').last.toUpperCase();
+  final path = Uri.tryParse(imageUrl)?.path ?? imageUrl;
+  final imageFormat = path.contains('.') ? path.split('.').last.toUpperCase() : 'UNKNOWN';
   final logger = Logger('handleImageError');
   logger.warning('Failed to load image $imageUrl: $error, $stackTrace');
 
   // NOTE: for the moment the other error messages are not localized
-  String message = '';
-  switch (error.runtimeType) {
-    case NetworkImageLoadException:
-      message = 'Network error';
-    case HttpException:
-      message = 'Http error';
-    case FormatException:
-      //TODO: not sure if this is the right exception for unsupported image formats?
-      message = AppLocalizations.of(context).imageFormatNotSupported(imageFormat);
-    default:
-      message = 'Other exception';
-  }
+  final message = switch (error) {
+    NetworkImageLoadException _ => 'Network error',
+    HttpException _ => 'Server connection failed',
+    SocketException _ => 'No internet connection',
+    //TODO: not sure if this is the right exception for unsupported image formats?
+    FormatException _ => AppLocalizations.of(context).imageFormatNotSupported(imageFormat),
+    _ => 'An unexpected error occurred',
+  };
 
   return AspectRatio(
     aspectRatio: 1,


### PR DESCRIPTION
In `offline-mode` branch, `Routine` model was being mutated in-place during exercise replacement, leading to UI sync issues where widgets do not rebuild despite the underlying data changing.

# Proposed Changes

* **Model (`lib/models/workouts/routine.dart`):**
    * Implemented `copyWith()` method for the `Routine` class.
    * Refactored `replaceExercise` from a `void` (mutating) method to a functional method that returns a new `Routine` instance.
    * Ensured nested lists (`sessions`, `dayData`, `dayDataGym`) are cloned using `List.from()` to prevent shared references between state snapshots.
* **Provider (`lib/providers/gym_state.dart`):**
    * Refactored `replaceExercises` in `GymStateNotifier` to capture the new `Routine` instance returned by the model.

* **Other refactor (`lib/widgets/core/image.dart`):**
    * Replace manual type checking with Dart switch expressions

## Related Issue(s)

<!-- If applicable, please link to any related issues "Closes #123", -->
<!-- "Closes wger-project/other-repo#123", "See also #123", etc.      -->

## Please check that the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Set a 100-character limit to avoid white space diffs (run `dart format .`)
