### PR TITLE
fix: make routineId nullable to prevent crash on free workout logs

### DIFF
--- a/lib/database/powersync/database.g.dart
+++ b/lib/database/powersync/database.g.dart
@@ -5973,7 +5973,7 @@ class $WorkoutLogTableTable extends WorkoutLogTable with TableInfo<$WorkoutLogTa
       routineId: attachedDatabase.typeMapping.read(
         DriftSqlType.int,
         data['${effectivePrefix}routine_id'],
-      )!,
+      ),
       sessionId: attachedDatabase.typeMapping.read(
         DriftSqlType.string,
         data['${effectivePrefix}session_id'],
@@ -6122,7 +6122,7 @@ class WorkoutLogTableCompanion extends UpdateCompanion<Log> {
   WorkoutLogTableCompanion copyWith({
     Value<String>? id,
     Value<int>? exerciseId,
-    Value<int>? routineId,
+    Value<int?>? routineId,
     Value<String?>? sessionId,
     Value<int?>? iteration,
     Value<int?>? slotEntryId,

--- a/lib/database/powersync/database.g.dart
+++ b/lib/database/powersync/database.g.dart
@@ -5685,9 +5685,9 @@ class $WorkoutLogTableTable extends WorkoutLogTable with TableInfo<$WorkoutLogTa
   late final GeneratedColumn<int> routineId = GeneratedColumn<int>(
     'routine_id',
     aliasedName,
-    false,
+    true,
     type: DriftSqlType.int,
-    requiredDuringInsert: true,
+    requiredDuringInsert: false,
   );
   static const VerificationMeta _sessionIdMeta = const VerificationMeta(
     'sessionId',
@@ -5860,8 +5860,6 @@ class $WorkoutLogTableTable extends WorkoutLogTable with TableInfo<$WorkoutLogTa
         _routineIdMeta,
         routineId.isAcceptableOrUnknown(data['routine_id']!, _routineIdMeta),
       );
-    } else if (isInserting) {
-      context.missing(_routineIdMeta);
     }
     if (data.containsKey('session_id')) {
       context.handle(
@@ -6032,7 +6030,7 @@ class $WorkoutLogTableTable extends WorkoutLogTable with TableInfo<$WorkoutLogTa
 class WorkoutLogTableCompanion extends UpdateCompanion<Log> {
   final Value<String> id;
   final Value<int> exerciseId;
-  final Value<int> routineId;
+  final Value<int?> routineId;
   final Value<String?> sessionId;
   final Value<int?> iteration;
   final Value<int?> slotEntryId;
@@ -6067,7 +6065,7 @@ class WorkoutLogTableCompanion extends UpdateCompanion<Log> {
   WorkoutLogTableCompanion.insert({
     this.id = const Value.absent(),
     required int exerciseId,
-    required int routineId,
+    this.routineId = const Value.absent(),
     this.sessionId = const Value.absent(),
     this.iteration = const Value.absent(),
     this.slotEntryId = const Value.absent(),
@@ -6082,7 +6080,6 @@ class WorkoutLogTableCompanion extends UpdateCompanion<Log> {
     required DateTime date,
     this.rowid = const Value.absent(),
   }) : exerciseId = Value(exerciseId),
-       routineId = Value(routineId),
        date = Value(date);
   static Insertable<Log> custom({
     Expression<String>? id,
@@ -17256,7 +17253,7 @@ typedef $$WorkoutLogTableTableCreateCompanionBuilder =
     WorkoutLogTableCompanion Function({
       Value<String> id,
       required int exerciseId,
-      required int routineId,
+      Value<int?> routineId,
       Value<String?> sessionId,
       Value<int?> iteration,
       Value<int?> slotEntryId,
@@ -17275,7 +17272,7 @@ typedef $$WorkoutLogTableTableUpdateCompanionBuilder =
     WorkoutLogTableCompanion Function({
       Value<String> id,
       Value<int> exerciseId,
-      Value<int> routineId,
+      Value<int?> routineId,
       Value<String?> sessionId,
       Value<int?> iteration,
       Value<int?> slotEntryId,
@@ -17565,7 +17562,7 @@ class $$WorkoutLogTableTableTableManager
               ({
                 Value<String> id = const Value.absent(),
                 Value<int> exerciseId = const Value.absent(),
-                Value<int> routineId = const Value.absent(),
+                Value<int?> routineId = const Value.absent(),
                 Value<String?> sessionId = const Value.absent(),
                 Value<int?> iteration = const Value.absent(),
                 Value<int?> slotEntryId = const Value.absent(),
@@ -17601,7 +17598,7 @@ class $$WorkoutLogTableTableTableManager
               ({
                 Value<String> id = const Value.absent(),
                 required int exerciseId,
-                required int routineId,
+                Value<int?> routineId = const Value.absent(),
                 Value<String?> sessionId = const Value.absent(),
                 Value<int?> iteration = const Value.absent(),
                 Value<int?> slotEntryId = const Value.absent(),

--- a/lib/database/powersync/tables/routines.dart
+++ b/lib/database/powersync/tables/routines.dart
@@ -65,7 +65,7 @@ class WorkoutLogTable extends Table {
 
   TextColumn get id => text().clientDefault(() => ps.uuid.v7())();
   IntColumn get exerciseId => integer().named('exercise_id')();
-  IntColumn get routineId => integer().named('routine_id')();
+  IntColumn get routineId => integer().named('routine_id').nullable()();
   TextColumn get sessionId => text().named('session_id').nullable()();
   IntColumn get iteration => integer().nullable()();
   IntColumn get slotEntryId => integer().named('slot_entry_id').nullable()();

--- a/lib/features/routines/models/log.dart
+++ b/lib/features/routines/models/log.dart
@@ -84,7 +84,7 @@ class Log {
     DateTime? date,
   }) : date = date ?? DateTime.now();
 
-  Log.fromSetConfigData(SetConfigData setConfig, {int? routineId, this.iteration}) {
+  Log.fromSetConfigData(SetConfigData setConfig, {this.routineId, this.iteration}) {
     date = DateTime.now();
     sessionId = null;
 
@@ -103,10 +103,6 @@ class Log {
 
     rir = setConfig.rir;
     rirTarget = setConfig.rir;
-
-    if (routineId != null) {
-      this.routineId = routineId;
-    }
   }
 
   Log copyWith({
@@ -166,7 +162,7 @@ class Log {
     return WorkoutLogTableCompanion(
       id: id != null ? drift.Value(id!) : const drift.Value.absent(),
       exerciseId: drift.Value(exerciseId),
-      routineId: routineId != null ? drift.Value(routineId) : const drift.Value.absent(),
+      routineId: drift.Value(routineId),
       sessionId: sessionId != null ? drift.Value(sessionId) : const drift.Value.absent(),
       iteration: iteration != null ? drift.Value(iteration) : const drift.Value.absent(),
       slotEntryId: slotEntryId != null ? drift.Value(slotEntryId) : const drift.Value.absent(),

--- a/lib/features/routines/models/log.dart
+++ b/lib/features/routines/models/log.dart
@@ -45,7 +45,7 @@ class Log {
   late int exerciseId;
   late Exercise exerciseObj;
 
-  late int routineId;
+  int? routineId;
   String? sessionId;
   int? iteration;
   int? slotEntryId;
@@ -69,7 +69,7 @@ class Log {
     required this.exerciseId,
     this.iteration,
     this.slotEntryId,
-    required this.routineId,
+    this.routineId,
     this.sessionId,
     this.repetitions,
     this.repetitionsTarget,
@@ -166,7 +166,7 @@ class Log {
     return WorkoutLogTableCompanion(
       id: id != null ? drift.Value(id!) : const drift.Value.absent(),
       exerciseId: drift.Value(exerciseId),
-      routineId: drift.Value(routineId),
+      routineId: routineId != null ? drift.Value(routineId) : const drift.Value.absent(),
       sessionId: sessionId != null ? drift.Value(sessionId) : const drift.Value.absent(),
       iteration: iteration != null ? drift.Value(iteration) : const drift.Value.absent(),
       slotEntryId: slotEntryId != null ? drift.Value(slotEntryId) : const drift.Value.absent(),

--- a/lib/features/routines/providers/gym_state_notifier.dart
+++ b/lib/features/routines/providers/gym_state_notifier.dart
@@ -300,9 +300,11 @@ class GymStateNotifier extends _$GymStateNotifier {
       return;
     }
 
-    final log = Log.fromSetConfigData(slotEntryPage.setConfigData!);
-    log.routineId = state.routine.id!;
-    log.iteration = state.iteration;
+    final log = Log.fromSetConfigData(
+      slotEntryPage.setConfigData!,
+      routineId: state.routine.id,
+      iteration: state.iteration,
+    );
     ref.read(gymLogProvider.notifier).setLog(log);
   }
 

--- a/lib/features/routines/providers/gym_state_notifier.g.dart
+++ b/lib/features/routines/providers/gym_state_notifier.g.dart
@@ -40,7 +40,7 @@ final class GymStateNotifierProvider extends $NotifierProvider<GymStateNotifier,
   }
 }
 
-String _$gymStateNotifierHash() => r'cb812e35fc5aafcecb9b2cad0b220cce7b3190bf';
+String _$gymStateNotifierHash() => r'a1f2137bdf3d44c660a74979480f1ff39d11ec58';
 
 abstract class _$GymStateNotifier extends $Notifier<GymModeState> {
   GymModeState build();

--- a/lib/features/routines/providers/workout_logs_repository.dart
+++ b/lib/features/routines/providers/workout_logs_repository.dart
@@ -125,7 +125,9 @@ class WorkoutLogRepository {
         final existing =
             await (_db.select(_db.workoutSessionTable)
                   ..where(
-                    (t) => t.routineId.equals(log.routineId) & t.date.equalsValue(dayMidnightUtc),
+                    (t) =>
+                        t.routineId.equalsNullable(log.routineId) &
+                        t.date.equalsValue(dayMidnightUtc),
                   )
                   ..limit(1))
                 .getSingleOrNull();

--- a/lib/features/routines/widgets/forms/session.dart
+++ b/lib/features/routines/widgets/forms/session.dart
@@ -30,7 +30,7 @@ import 'package:wger/l10n/generated/app_localizations.dart';
 
 class SessionForm extends ConsumerStatefulWidget {
   final _logger = Logger('SessionForm');
-  final int _routineId;
+  final int? _routineId;
   final int? _dayId;
 
   /// The session to edit, or null to create a new one.

--- a/lib/features/routines/widgets/gym_mode/session_page.dart
+++ b/lib/features/routines/widgets/gym_mode/session_page.dart
@@ -75,7 +75,7 @@ class _SessionPageState extends ConsumerState<SessionPage> {
                   Padding(
                     padding: const EdgeInsets.symmetric(horizontal: 15),
                     child: SessionForm(
-                      gymState.routine.id!,
+                      gymState.routine.id,
                       onSaved: () => widget._controller.nextPage(
                         duration: DEFAULT_ANIMATION_DURATION,
                         curve: DEFAULT_ANIMATION_CURVE,

--- a/lib/features/routines/widgets/logs/session_info.dart
+++ b/lib/features/routines/widgets/logs/session_info.dart
@@ -55,7 +55,7 @@ class _SessionInfoState extends State<SessionInfo> {
           ),
           if (editMode)
             SessionForm(
-              widget._session.routineId!,
+              widget._session.routineId,
               onSaved: () => setState(() => editMode = false),
               session: widget._session,
             )

--- a/test/features/routines/providers/workout_logs_repository_test.dart
+++ b/test/features/routines/providers/workout_logs_repository_test.dart
@@ -1,6 +1,6 @@
 /*
  * This file is part of wger Workout Manager <https://github.com/wger-project>.
- * Copyright (c) 2026 wger Team
+ * Copyright (c) 2026 - 2026 wger Team
  *
  * wger Workout Manager is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -39,7 +39,7 @@ void main() {
 
   Log makeLog({
     int exerciseId = 1,
-    int routineId = 100,
+    int? routineId = 100,
     String? sessionId,
     DateTime? date,
     num weight = 50,
@@ -151,6 +151,44 @@ void main() {
 
       expect(await readSessions(), hasLength(2));
     });
+
+    test('creates a session without a routine for a log without a routine', () async {
+      final log = makeLog(routineId: null, date: DateTime.utc(2026, 4, 15, 18));
+
+      await repo.addLocalDrift(log);
+
+      final sessions = await readSessions();
+      expect(sessions, hasLength(1));
+      expect(sessions.single.routineId, isNull);
+      expect(log.sessionId, sessions.single.id);
+    });
+
+    test('reuses an existing session without a routine for a log without a routine', () async {
+      final existingSession = WorkoutSession(
+        id: 'free-session',
+        routineId: null,
+        date: DateTime.utc(2026, 4, 15),
+      );
+      await db.into(db.workoutSessionTable).insert(existingSession.toCompanion());
+
+      final log = makeLog(routineId: null, date: DateTime.utc(2026, 4, 15, 18));
+      await repo.addLocalDrift(log);
+
+      expect(await readSessions(), hasLength(1));
+      expect(log.sessionId, existingSession.id);
+    });
+
+    test('does not attach a log without a routine to a session with one', () async {
+      await db
+          .into(db.workoutSessionTable)
+          .insert(
+            WorkoutSession(routineId: 100, date: DateTime.utc(2026, 4, 15)).toCompanion(),
+          );
+
+      await repo.addLocalDrift(makeLog(routineId: null, date: DateTime.utc(2026, 4, 15)));
+
+      expect(await readSessions(), hasLength(2));
+    });
   });
 
   group('updateLocalDrift', () {
@@ -240,6 +278,21 @@ void main() {
 
       expect(logs.single.repetitionsUnitObj?.name, 'Repetitions');
       expect(logs.single.weightUnitObj?.name, 'kg');
+    });
+
+    test('returns logs without a routine, e.g. free logging on the server', () async {
+      // The server allows logs without a routine. Such a row arrives via
+      // PowerSync with routine_id = NULL and must map cleanly
+      await seedUnits();
+      await db.customStatement(
+        'INSERT INTO manager_workoutlog (id, exercise_id, routine_id, weight, date) '
+        "VALUES ('free-log', 1, NULL, 50.0, '2026-04-15T10:30:00.000Z')",
+      );
+
+      final logs = await repo.watchLogsByExerciseDrift(exerciseId: 1).first;
+
+      expect(logs, hasLength(1));
+      expect(logs.single.routineId, isNull);
     });
 
     test('returns the logs of every routine when no routine is given', () async {


### PR DESCRIPTION
## Summary

Makes `routineId` nullable in `WorkoutLogTable` and `Log` model to fix a crash when workout logs have no associated routine.

## Problem

The server allows workout logs without a routine (free/ad-hoc logging): `routine = ForeignKey('Routine', ..., null=True)`. However, the app's Drift table declared `routineId` as **non-nullable**, causing:

```
Null check operator used on a null value
```

in `WorkoutLogTableTable.map` when PowerSync delivers a row with `routine_id = NULL`.

## Changes

- `WorkoutLogTable.routineId`: `integer()` → `integer().nullable()`
- `Log.routineId`: `late int` → `int?`
- `Log` constructor: `required this.routineId` → `this.routineId`
- `Log.toCompanion`: handle null routineId with `Value.absent()`

## Testing

Verified that the app no longer crashes when opening a routine that has workout logs without an associated routine.

Fixes #1250
