### PR TITLE
Add elapsed workout timer to gym mode

### DIFF
--- a/lib/features/routines/providers/gym_state.dart
+++ b/lib/features/routines/providers/gym_state.dart
@@ -170,7 +170,9 @@ class GymModeState {
   final List<PageEntry> pages;
   final int currentPage;
 
-  final TimeOfDay startTime;
+  /// Moment the workout was started, with full seconds precision. Set when
+  /// gym mode is opened and reset when the user taps "start".
+  final DateTime workoutStart;
   final DateTime validUntil;
 
   // User settings
@@ -204,9 +206,9 @@ class GymModeState {
     Routine? routine,
 
     DateTime? validUntil,
-    TimeOfDay? startTime,
+    DateTime? workoutStart,
   }) : validUntil = validUntil ?? clock.now().add(DEFAULT_DURATION),
-       startTime = startTime ?? TimeOfDay.fromDateTime(clock.now()) {
+       workoutStart = workoutStart ?? clock.now() {
     if (dayId != null) {
       this.dayId = dayId;
     }
@@ -230,7 +232,7 @@ class GymModeState {
     int? dayId,
     int? iteration,
     DateTime? validUntil,
-    TimeOfDay? startTime,
+    DateTime? workoutStart,
     Routine? routine,
 
     // User settings
@@ -251,7 +253,7 @@ class GymModeState {
       dayId: dayId ?? this.dayId,
       iteration: iteration ?? this.iteration,
       validUntil: validUntil ?? this.validUntil,
-      startTime: startTime ?? this.startTime,
+      workoutStart: workoutStart ?? this.workoutStart,
       routine: routine ?? this.routine,
 
       showExercisePages: showExercisePages ?? this.showExercisePages,
@@ -265,6 +267,9 @@ class GymModeState {
       showDistinctLogs: showDistinctLogs ?? this.showDistinctLogs,
     );
   }
+
+  /// The start of the workout as a [TimeOfDay], e.g. for the session form
+  TimeOfDay get startTime => TimeOfDay.fromDateTime(workoutStart);
 
   int get totalPages {
     // Main pages (start, session, etc.)
@@ -330,7 +335,7 @@ class GymModeState {
     return 'GymState('
         'currentPage: $currentPage, '
         'validUntil: $validUntil '
-        'startTime: $startTime, '
+        'workoutStart: $workoutStart, '
         'showExercisePages: $showExercisePages, '
         'showTimerPages: $showTimerPages, '
         ')';

--- a/lib/features/routines/providers/gym_state_notifier.dart
+++ b/lib/features/routines/providers/gym_state_notifier.dart
@@ -453,6 +453,12 @@ class GymStateNotifier extends _$GymStateNotifier {
     recalculateIndices();
   }
 
+  /// Resets the workout start time to now, e.g. when the user taps "start"
+  void startWorkout() {
+    _logger.fine('Setting workout start time');
+    state = state.copyWith(workoutStart: clock.now());
+  }
+
   void clear() {
     _logger.fine('Clearing state');
     state = state.copyWith(
@@ -461,7 +467,7 @@ class GymStateNotifier extends _$GymStateNotifier {
       currentPage: 0,
 
       validUntil: clock.now().add(DEFAULT_DURATION),
-      startTime: null,
+      workoutStart: clock.now(),
     );
   }
 }

--- a/lib/features/routines/widgets/gym_mode/elapsed_time.dart
+++ b/lib/features/routines/widgets/gym_mode/elapsed_time.dart
@@ -1,0 +1,89 @@
+/*
+ * This file is part of wger Workout Manager <https://github.com/wger-project>.
+ * Copyright (c)  2026 wger Team
+ *
+ * wger Workout Manager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import 'dart:async';
+
+import 'package:clock/clock.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:wger/features/routines/providers/gym_state_notifier.dart';
+
+/// Shows the time elapsed since the start of the current workout.
+///
+/// Reads the start time from the shared gym state so that the value is
+/// consistent across all gym mode pages and with the times logged in the
+/// workout session.
+class ElapsedWorkoutTimer extends ConsumerStatefulWidget {
+  const ElapsedWorkoutTimer({super.key});
+
+  /// Formats a duration as `m:ss`, or `h:mm:ss` from one hour onwards
+  static String format(Duration elapsed) {
+    final hours = elapsed.inHours;
+    final minutes = elapsed.inMinutes.remainder(60);
+    final seconds = elapsed.inSeconds.remainder(60);
+
+    final secondsStr = seconds.toString().padLeft(2, '0');
+    if (hours > 0) {
+      return '$hours:${minutes.toString().padLeft(2, '0')}:$secondsStr';
+    }
+    return '$minutes:$secondsStr';
+  }
+
+  @override
+  ConsumerState<ElapsedWorkoutTimer> createState() => _ElapsedWorkoutTimerState();
+}
+
+class _ElapsedWorkoutTimerState extends ConsumerState<ElapsedWorkoutTimer> {
+  late Timer _uiTimer;
+
+  @override
+  void initState() {
+    super.initState();
+    _uiTimer = Timer.periodic(const Duration(seconds: 1), (_) {
+      // ignore: no-empty-block, avoid-empty-setstate
+      if (mounted) {
+        setState(() {});
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _uiTimer.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final workoutStart = ref.watch(gymStateProvider).workoutStart;
+    final elapsed = clock.now().difference(workoutStart);
+    final style = Theme.of(context).textTheme.bodySmall;
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(Icons.timer_outlined, size: 16, color: style?.color),
+        const SizedBox(width: 2),
+        Text(
+          ElapsedWorkoutTimer.format(elapsed.isNegative ? Duration.zero : elapsed),
+          style: style,
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/routines/widgets/gym_mode/navigation.dart
+++ b/lib/features/routines/widgets/gym_mode/navigation.dart
@@ -20,6 +20,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:wger/core/consts.dart';
 import 'package:wger/features/routines/providers/gym_state_notifier.dart';
+import 'package:wger/features/routines/widgets/gym_mode/elapsed_time.dart';
 import 'package:wger/features/routines/widgets/gym_mode/workout_menu.dart';
 import 'package:wger/theme/theme.dart';
 
@@ -73,11 +74,13 @@ class NavigationFooter extends ConsumerWidget {
   final PageController _controller;
   final bool showPrevious;
   final bool showNext;
+  final bool showElapsedTime;
 
   const NavigationFooter(
     this._controller, {
     this.showPrevious = true,
     this.showNext = true,
+    this.showElapsedTime = true,
   });
 
   @override
@@ -98,6 +101,10 @@ class NavigationFooter extends ConsumerWidget {
           )
         else
           const SizedBox(width: 48),
+        if (showElapsedTime) ...[
+          const ElapsedWorkoutTimer(),
+          const SizedBox(width: 8),
+        ],
         Expanded(
           child: GestureDetector(
             onTap: () => showDialog(

--- a/lib/features/routines/widgets/gym_mode/start_page.dart
+++ b/lib/features/routines/widgets/gym_mode/start_page.dart
@@ -275,13 +275,14 @@ class StartPage extends ConsumerWidget {
         FilledButton(
           child: Text(AppLocalizations.of(context).start),
           onPressed: () {
+            ref.read(gymStateProvider.notifier).startWorkout();
             _controller.nextPage(
               duration: const Duration(milliseconds: 200),
               curve: Curves.bounceIn,
             );
           },
         ),
-        NavigationFooter(_controller, showPrevious: false),
+        NavigationFooter(_controller, showPrevious: false, showElapsedTime: false),
       ],
     );
   }

--- a/test/features/routines/providers/gym_state_test.dart
+++ b/test/features/routines/providers/gym_state_test.dart
@@ -16,6 +16,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import 'package:clock/clock.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences_platform_interface/in_memory_shared_preferences_async.dart';
@@ -304,6 +306,37 @@ void main() {
       // Assert
       expect(notifier.state.logScopeWeeks, isNull);
       expect(await PreferenceHelper.asyncPref.getInt(PREFS_LOG_SCOPE_WEEKS), isNull);
+    });
+  });
+
+  group('GymStateNotifier.startWorkout', () {
+    test('Resets the workout start time to now', () {
+      // Arrange
+      notifier.state = notifier.state.copyWith(workoutStart: DateTime(2024, 5, 1, 10, 0));
+
+      // Act
+      withClock(Clock.fixed(DateTime(2024, 5, 1, 17, 30, 21)), () {
+        notifier.startWorkout();
+      });
+
+      // Assert
+      expect(notifier.state.workoutStart, DateTime(2024, 5, 1, 17, 30, 21));
+      expect(notifier.state.startTime, const TimeOfDay(hour: 17, minute: 30));
+    });
+  });
+
+  group('GymStateNotifier.clear', () {
+    test('Resets the workout start time', () {
+      // Arrange
+      notifier.state = notifier.state.copyWith(workoutStart: DateTime(2024, 5, 1, 10, 0));
+
+      // Act
+      withClock(Clock.fixed(DateTime(2024, 5, 2, 9, 15)), () {
+        notifier.clear();
+      });
+
+      // Assert
+      expect(notifier.state.workoutStart, DateTime(2024, 5, 2, 9, 15));
     });
   });
 

--- a/test/features/routines/widgets/gym_mode/elapsed_time_test.dart
+++ b/test/features/routines/widgets/gym_mode/elapsed_time_test.dart
@@ -1,0 +1,102 @@
+/*
+ * This file is part of wger Workout Manager <https://github.com/wger-project>.
+ * Copyright (c)  2026 wger Team
+ *
+ * wger Workout Manager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import 'package:clock/clock.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:wger/features/routines/providers/gym_state.dart';
+import 'package:wger/features/routines/providers/gym_state_notifier.dart';
+import 'package:wger/features/routines/widgets/gym_mode/elapsed_time.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late ProviderContainer container;
+
+  setUp(() {
+    container = ProviderContainer(
+      overrides: [
+        gymStateProvider.overrideWith(() => GymStateNotifier()),
+      ],
+    );
+  });
+
+  tearDown(() {
+    container.dispose();
+  });
+
+  Future<void> pumpTimer(WidgetTester tester) async {
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(
+          home: Scaffold(
+            body: ElapsedWorkoutTimer(),
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('Shows the time elapsed since the workout start', (tester) async {
+    final now = DateTime(2024, 5, 1, 12, 0, 0);
+
+    await withClock(Clock.fixed(now), () async {
+      final notifier = container.read(gymStateProvider.notifier);
+      notifier.state = GymModeState(
+        workoutStart: now.subtract(const Duration(minutes: 1, seconds: 5)),
+      );
+
+      await pumpTimer(tester);
+
+      expect(find.text('1:05'), findsOneWidget);
+    });
+  });
+
+  testWidgets('Shows zero for a workout start in the future', (tester) async {
+    final now = DateTime(2024, 5, 1, 12, 0, 0);
+
+    await withClock(Clock.fixed(now), () async {
+      final notifier = container.read(gymStateProvider.notifier);
+      notifier.state = GymModeState(
+        workoutStart: now.add(const Duration(minutes: 5)),
+      );
+
+      await pumpTimer(tester);
+
+      expect(find.text('0:00'), findsOneWidget);
+    });
+  });
+
+  group('ElapsedWorkoutTimer.format', () {
+    test('Formats durations under an hour as m:ss', () {
+      expect(ElapsedWorkoutTimer.format(Duration.zero), '0:00');
+      expect(ElapsedWorkoutTimer.format(const Duration(seconds: 9)), '0:09');
+      expect(ElapsedWorkoutTimer.format(const Duration(minutes: 59, seconds: 59)), '59:59');
+    });
+
+    test('Formats durations over an hour as h:mm:ss', () {
+      expect(ElapsedWorkoutTimer.format(const Duration(hours: 1)), '1:00:00');
+      expect(
+        ElapsedWorkoutTimer.format(const Duration(hours: 2, minutes: 3, seconds: 4)),
+        '2:03:04',
+      );
+    });
+  });
+}

--- a/test/features/routines/widgets/gym_mode/session_page_test.dart
+++ b/test/features/routines/widgets/gym_mode/session_page_test.dart
@@ -115,7 +115,7 @@ void main() {
 
     notifier.state = notifier.state.copyWith(
       routine: testRoutine,
-      startTime: const TimeOfDay(hour: 13, minute: 35),
+      workoutStart: DateTime(2021, 5, 1, 13, 35),
     );
     notifier.calculatePages();
 
@@ -131,7 +131,7 @@ void main() {
     // Arrange
     testRoutine.sessions = [];
     notifier.state = notifier.state.copyWith(
-      startTime: const TimeOfDay(hour: 13, minute: 35),
+      workoutStart: DateTime(2021, 5, 1, 13, 35),
     );
 
     // Act


### PR DESCRIPTION

# Proposed Changes

- Add a live elapsed-time display (`ElapsedWorkoutTimer`) to the gym mode navigation
  footer, next to the progress bar, so it is visible on every page of the workout
- The timer starts when the user taps "Start" on the first gym mode page; the same
  start time is used to pre-fill the workout session form, so the logged session
  duration matches what the timer showed
- Store the workout start with seconds precision (`DateTime workoutStart`) in
  `GymModeState`; the previous `TimeOfDay startTime` is kept as a getter so the
  session form behavior is unchanged
- Fix a bug where `GymStateNotifier.clear()` never actually reset the start time
  (passing `startTime: null` to `copyWith` was a no-op), which carried the previous
  workout's start time into the next workout in the same app session

## Related Issue(s)

Closes #1130

## Please check that the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Set a 100-character limit to avoid white space diffs (run `dart format .`)