### PR TITLE
Fix crash when copying a log with no hydrated exercise

### DIFF
--- a/lib/features/routines/models/log.dart
+++ b/lib/features/routines/models/log.dart
@@ -43,7 +43,25 @@ class Log {
   String? id;
 
   late int exerciseId;
-  late Exercise exerciseObj;
+
+  Exercise? _exerciseObj;
+
+  /// The exercise this log belongs to, throws if it was never hydrated
+  ///
+  /// Logs read from the database only carry [exerciseId], joining the whole
+  /// exercise with its translations, images and muscles would be wasteful for
+  /// a value most callers don't need. Use [exerciseObjOrNull] for those.
+  Exercise get exerciseObj {
+    if (_exerciseObj == null) {
+      throw StateError('Log $id has no hydrated exercise (exercise ID $exerciseId)');
+    }
+    return _exerciseObj!;
+  }
+
+  set exerciseObj(Exercise value) => _exerciseObj = value;
+
+  /// Like [exerciseObj] but returns null instead of throwing
+  Exercise? get exerciseObjOrNull => _exerciseObj;
 
   int? routineId;
   String? sessionId;
@@ -153,7 +171,11 @@ class Log {
       out.weightUnitObj = weightUnitObj;
       out.weightUnitId = weightUnitObj.id;
     }
-    out.exerciseObj = exerciseObj;
+
+    // Logs read from the database have no exercise, so only copy an existing one
+    if (_exerciseObj != null) {
+      out.exerciseObj = _exerciseObj!;
+    }
 
     return out;
   }

--- a/lib/features/routines/providers/gym_log_notifier.dart
+++ b/lib/features/routines/providers/gym_log_notifier.dart
@@ -19,6 +19,7 @@
 import 'package:clock/clock.dart';
 import 'package:logging/logging.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:wger/features/exercises/models/exercise.dart';
 import 'package:wger/features/routines/models/log.dart';
 import 'package:wger/features/routines/models/repetition_unit.dart';
 import 'package:wger/features/routines/models/weight_unit.dart';
@@ -35,12 +36,19 @@ class GymLogNotifier extends _$GymLogNotifier {
     return null;
   }
 
-  void setLog(Log log) {
+  /// Pass [exercise] to hydrate the copy, logs read from the database only
+  /// carry their exercise ID
+  void setLog(Log log, {Exercise? exercise}) {
     // Clear the id so Drift mints a fresh UUID on insert, and the sessionId so
     // the copy lands in today's session instead of the template's historical one.
-    state = log.copyWith(date: clock.now())
+    final out = log.copyWith(date: clock.now())
       ..id = null
       ..sessionId = null;
+
+    if (exercise != null) {
+      out.exercise = exercise;
+    }
+    state = out;
   }
 
   void setWeight(num weight) {

--- a/lib/features/routines/widgets/gym_mode/log_page.dart
+++ b/lib/features/routines/widgets/gym_mode/log_page.dart
@@ -24,6 +24,7 @@ import 'package:wger/core/formatting/formatting.dart';
 import 'package:wger/core/snackbar.dart';
 import 'package:wger/core/widgets/core.dart';
 import 'package:wger/core/widgets/error.dart';
+import 'package:wger/features/exercises/models/exercise.dart';
 import 'package:wger/features/routines/models/log.dart';
 import 'package:wger/features/routines/models/set_config_data.dart';
 import 'package:wger/features/routines/models/slot_entry.dart';
@@ -142,7 +143,7 @@ class LogPage extends ConsumerWidget {
         // Overriding the log scope from here is handled in a follow-up, the
         // settings currently only live in the gym mode options.
         // _LogScopeControls(gymState: gymState),
-        Expanded(child: _buildPastLogs(pastLogs)),
+        Expanded(child: _buildPastLogs(pastLogs, setConfigData.exercise)),
 
         Padding(
           padding: const EdgeInsets.all(10),
@@ -165,7 +166,7 @@ class LogPage extends ConsumerWidget {
   }
 
   /// Renders the previous logs for this exercise
-  Widget _buildPastLogs(AsyncValue<List<Log>> pastLogs) {
+  Widget _buildPastLogs(AsyncValue<List<Log>> pastLogs, Exercise exercise) {
     if (pastLogs.hasError) {
       _logger.warning('Could not load past logs', pastLogs.error, pastLogs.stackTrace);
       // Scroll-wrap so the indicator fits this slim slot instead of overflowing.
@@ -174,7 +175,9 @@ class LogPage extends ConsumerWidget {
       );
     }
     final logs = pastLogs.value ?? const <Log>[];
-    return logs.isEmpty ? const SizedBox.shrink() : LogsPastLogsWidget(pastLogs: logs);
+    return logs.isEmpty
+        ? const SizedBox.shrink()
+        : LogsPastLogsWidget(pastLogs: logs, exercise: exercise);
   }
 }
 
@@ -235,9 +238,13 @@ class LogsPlatesWidget extends ConsumerWidget {
 class LogsPastLogsWidget extends ConsumerWidget {
   final List<Log> pastLogs;
 
+  /// The exercise the logs belong to, they only carry its ID
+  final Exercise exercise;
+
   const LogsPastLogsWidget({
     super.key,
     required this.pastLogs,
+    required this.exercise,
   });
 
   @override
@@ -261,7 +268,7 @@ class LogsPastLogsWidget extends ConsumerWidget {
               subtitle: Text(dateFormat.format(pastLog.date)),
               trailing: const Icon(Icons.copy),
               onTap: () {
-                logProvider.setLog(pastLog);
+                logProvider.setLog(pastLog, exercise: exercise);
                 ScaffoldMessenger.of(context).hideCurrentSnackBar();
                 showSnackbar(context, AppLocalizations.of(context).dataCopied);
               },

--- a/test/features/routines/models/log_test.dart
+++ b/test/features/routines/models/log_test.dart
@@ -23,6 +23,8 @@ import 'package:wger/features/exercises/models/exercise.dart';
 import 'package:wger/features/routines/models/log.dart';
 import 'package:wger/features/routines/models/set_config_data.dart';
 
+import '../../../../test_data/exercises.dart';
+
 void main() {
   group('Log.volume', () {
     test('returns weight * repetitions for metric (kg) and repetition unit', () {
@@ -196,6 +198,40 @@ void main() {
       expect(log.repetitionsTarget, 12);
       expect(log.rir, 2);
       expect(log.rirTarget, 2);
+    });
+  });
+
+  group('Log exercise hydration', () {
+    /// A log as it comes out of the database, with only the exercise ID set
+    Log makeDriftLog() => Log(
+      id: 'log-1',
+      exerciseId: 1,
+      routineId: 100,
+      weight: 20,
+      repetitions: 10,
+      date: DateTime(2026, 1, 1),
+    );
+
+    test('copies a log whose exercise was never hydrated', () {
+      final copy = makeDriftLog().copyWith(date: DateTime(2026, 2, 2));
+
+      expect(copy.exerciseObjOrNull, isNull);
+    });
+
+    test('reading an unhydrated exercise throws a descriptive error', () {
+      expect(
+        () => makeDriftLog().exerciseObj,
+        throwsA(isA<StateError>().having((e) => e.message, 'message', contains('log-1'))),
+      );
+    });
+
+    test('propagates the exercise when it is hydrated', () {
+      final log = makeDriftLog()..exercise = testBenchPress;
+
+      final copy = log.copyWith(weight: 30);
+
+      expect(copy.exerciseObj.id, testBenchPress.id);
+      expect(copy.exerciseId, testBenchPress.id);
     });
   });
 

--- a/test/features/routines/providers/gym_log_notifier_test.dart
+++ b/test/features/routines/providers/gym_log_notifier_test.dart
@@ -41,8 +41,6 @@ void main() {
     num repetitions = 10,
     DateTime? date,
   }) {
-    // Log.copyWith reads exerciseObj internally, so it must be set before
-    // setLog (which calls copyWith) is invoked.
     return Log(
       id: id ?? 'log-1',
       exerciseId: exerciseId,
@@ -50,11 +48,27 @@ void main() {
       weight: weight,
       repetitions: repetitions,
       date: date ?? DateTime.utc(2020, 1, 1),
-    )..exerciseObj = testBenchPress;
+    );
   }
 
   test('initial state is null', () {
     expect(container.read(gymLogProvider), isNull);
+  });
+
+  test('setLog accepts a log with no exercise, as read from the database', () {
+    container.read(gymLogProvider.notifier).setLog(makeLog());
+
+    final state = container.read(gymLogProvider)!;
+    expect(state.exerciseId, 1);
+    expect(state.exerciseObjOrNull, isNull);
+  });
+
+  test('setLog hydrates the exercise when the caller passes one', () {
+    container.read(gymLogProvider.notifier).setLog(makeLog(), exercise: testBenchPress);
+
+    final state = container.read(gymLogProvider)!;
+    expect(state.exerciseObj.id, testBenchPress.id);
+    expect(state.exerciseId, testBenchPress.id);
   });
 
   test('setLog stores a copy with cleared id/sessionId and the current clock as date', () {

--- a/test/features/routines/widgets/gym_mode/log_page_test.dart
+++ b/test/features/routines/widgets/gym_mode/log_page_test.dart
@@ -42,6 +42,23 @@ import '../../../../../test_data/exercises.dart';
 import '../../../../../test_data/routines.dart' as testdata;
 import 'log_page_test.mocks.dart';
 
+/// Strips the exercise off a fixture log, watchLogsByExerciseDrift only joins the units
+Log asDriftLog(Log log) =>
+    Log(
+        id: log.id,
+        exerciseId: log.exerciseId,
+        iteration: log.iteration,
+        slotEntryId: log.slotEntryId,
+        routineId: log.routineId,
+        sessionId: log.sessionId,
+        repetitions: log.repetitions,
+        rir: log.rir,
+        weight: log.weight,
+        date: log.date,
+      )
+      ..repetitionUnit = log.repetitionsUnitObj
+      ..weightUnit = log.weightUnitObj;
+
 @GenerateMocks([WorkoutLogRepository])
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -65,7 +82,9 @@ void main() {
         ),
       ).thenAnswer((invocation) {
         final exerciseId = invocation.namedArguments[#exerciseId] as int;
-        return Stream.value(testdata.getTestRoutine().filterLogsByExercise(exerciseId));
+        return Stream.value(
+          testdata.getTestRoutine().filterLogsByExercise(exerciseId).map(asDriftLog).toList(),
+        );
       });
       container = ProviderContainer.test(
         overrides: [workoutLogRepositoryProvider.overrideWithValue(mockWorkoutLogRepo)],


### PR DESCRIPTION
# Proposed Changes

- Fix `LateInitializationError: Field 'exerciseObj' has not been initialized` when copying a
  past log in gym mode. `Log.exerciseObj` becomes a nullable backing field with a throwing
  getter plus an `exerciseObjOrNull` accessor, and `Log.copyWith` only carries the exercise
  over when the source log actually has one.
- `GymLogNotifier.setLog` takes an optional `exercise`, and `LogsPastLogsWidget` passes the
  one it already has, so gym-mode state never ends up holding a log without an exercise.
- Make the gym-mode log fixtures match what drift really returns, so the regression is
  actually covered.

## Related Issue(s)

Closes #1286

## Details

Tapping an entry in the "Workout logs" list on an exercise's log page threw:

```
LateInitializationError: Field 'exerciseObj' has not been initialized.
#0   Log.copyWith (package:wger/features/routines/models/log.dart)
#1   GymLogNotifier.setLog (package:wger/features/routines/providers/gym_log_notifier.dart:41)
#2   LogsPastLogsWidget.build.<anonymous closure>.<anonymous closure>
     (package:wger/features/routines/widgets/gym_mode/log_page.dart:264)
```

### Two different ways a Log gets built

`Log.exerciseObj` was declared `late Exercise`, and only one code path ever assigned it:
`routines_notifier.dart:153`, which hydrates the logs hanging off a routine's sessions.

The gym-mode past-logs list does not use that path. It watches `pastExerciseLogsProvider`,
which goes to `WorkoutLogRepository.watchLogsByExerciseDrift()`. That query left-outer-joins
the repetition and weight unit tables and hydrates `repetitionUnit` / `weightUnit` on each
row, but never touches the exercise. Since `WorkoutLogTable` is `@UseRowClass(Log)`, drift
builds every row through the constructor, which only sets `exerciseId`.

So logs from the DB legitimately have no `exerciseObj` — and `copyWith` ended with an
unconditional read of it (`out.exerciseObj = exerciseObj;`). That is a precondition the real
data path simply cannot satisfy, and tapping a past log is exactly the case that hits it.

Deliberately *not* fixed by hydrating the exercise inside `watchLogsByExerciseDrift`:
exercises carry translations, images, muscles and equipment, and joining all of that per log
would be a real performance regression for a value most callers don't need. `Log.toCompanion()`
only persists `exerciseId`, so an unhydrated exercise never affects what is written to the DB.

### Why CI did not catch it

Both existing fixtures hid the bug:

- `log_page_test.dart` mocked `watchLogsByExerciseDrift` with
  `getTestRoutine().filterLogsByExercise(...)`, whose logs *are* hydrated — unlike real drift
  output. The mock is now mapped through a helper that strips the exercise, so the
  "copy from past log" test is a genuine regression test.
- `gym_log_notifier_test.dart` worked around it explicitly, with a comment saying
  `// Log.copyWith reads exerciseObj internally, so it must be set before setLog ... is invoked`
  followed by `..exerciseObj = testBenchPress`. That workaround was the bug, written down.
  It is gone.

### Note

`SlotEntry` has the same `late Exercise exerciseObj` pattern, but its hydration path
(`routines_notifier.dart:165`) is sound, so it is left alone to keep this PR focused.

## Please check that the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Set a 100-character limit to avoid white space diffs (run `dart format .`)
