### PR TITLE
Add notes field to WorkoutLog

### DIFF
--- a/lib/database/powersync/database.g.dart
+++ b/lib/database/powersync/database.g.dart
@@ -5806,6 +5806,15 @@ class $WorkoutLogTableTable extends WorkoutLogTable with TableInfo<$WorkoutLogTa
     type: DriftSqlType.int,
     requiredDuringInsert: false,
   );
+  static const VerificationMeta _notesMeta = const VerificationMeta('notes');
+  @override
+  late final GeneratedColumn<String> notes = GeneratedColumn<String>(
+    'notes',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
   @override
   late final GeneratedColumnWithTypeConverter<DateTime, DateTime> date = GeneratedColumn<DateTime>(
     'date',
@@ -5830,6 +5839,7 @@ class $WorkoutLogTableTable extends WorkoutLogTable with TableInfo<$WorkoutLogTa
     weight,
     weightTarget,
     weightUnitId,
+    notes,
     date,
   ];
   @override
@@ -5945,6 +5955,12 @@ class $WorkoutLogTableTable extends WorkoutLogTable with TableInfo<$WorkoutLogTa
         ),
       );
     }
+    if (data.containsKey('notes')) {
+      context.handle(
+        _notesMeta,
+        notes.isAcceptableOrUnknown(data['notes']!, _notesMeta),
+      );
+    }
     return context;
   }
 
@@ -6010,6 +6026,10 @@ class $WorkoutLogTableTable extends WorkoutLogTable with TableInfo<$WorkoutLogTa
         DriftSqlType.int,
         data['${effectivePrefix}weight_unit_id'],
       ),
+      notes: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}notes'],
+      ),
       date: $WorkoutLogTableTable.$converterdate.fromSql(
         attachedDatabase.typeMapping.read(
           DriftSqlType.dateTime,
@@ -6042,6 +6062,7 @@ class WorkoutLogTableCompanion extends UpdateCompanion<Log> {
   final Value<double?> weight;
   final Value<double?> weightTarget;
   final Value<int?> weightUnitId;
+  final Value<String?> notes;
   final Value<DateTime> date;
   final Value<int> rowid;
   const WorkoutLogTableCompanion({
@@ -6059,6 +6080,7 @@ class WorkoutLogTableCompanion extends UpdateCompanion<Log> {
     this.weight = const Value.absent(),
     this.weightTarget = const Value.absent(),
     this.weightUnitId = const Value.absent(),
+    this.notes = const Value.absent(),
     this.date = const Value.absent(),
     this.rowid = const Value.absent(),
   });
@@ -6077,6 +6099,7 @@ class WorkoutLogTableCompanion extends UpdateCompanion<Log> {
     this.weight = const Value.absent(),
     this.weightTarget = const Value.absent(),
     this.weightUnitId = const Value.absent(),
+    this.notes = const Value.absent(),
     required DateTime date,
     this.rowid = const Value.absent(),
   }) : exerciseId = Value(exerciseId),
@@ -6096,6 +6119,7 @@ class WorkoutLogTableCompanion extends UpdateCompanion<Log> {
     Expression<double>? weight,
     Expression<double>? weightTarget,
     Expression<int>? weightUnitId,
+    Expression<String>? notes,
     Expression<DateTime>? date,
     Expression<int>? rowid,
   }) {
@@ -6114,6 +6138,7 @@ class WorkoutLogTableCompanion extends UpdateCompanion<Log> {
       if (weight != null) 'weight': weight,
       if (weightTarget != null) 'weight_target': weightTarget,
       if (weightUnitId != null) 'weight_unit_id': weightUnitId,
+      if (notes != null) 'notes': notes,
       if (date != null) 'date': date,
       if (rowid != null) 'rowid': rowid,
     });
@@ -6134,6 +6159,7 @@ class WorkoutLogTableCompanion extends UpdateCompanion<Log> {
     Value<double?>? weight,
     Value<double?>? weightTarget,
     Value<int?>? weightUnitId,
+    Value<String?>? notes,
     Value<DateTime>? date,
     Value<int>? rowid,
   }) {
@@ -6152,6 +6178,7 @@ class WorkoutLogTableCompanion extends UpdateCompanion<Log> {
       weight: weight ?? this.weight,
       weightTarget: weightTarget ?? this.weightTarget,
       weightUnitId: weightUnitId ?? this.weightUnitId,
+      notes: notes ?? this.notes,
       date: date ?? this.date,
       rowid: rowid ?? this.rowid,
     );
@@ -6202,6 +6229,9 @@ class WorkoutLogTableCompanion extends UpdateCompanion<Log> {
     if (weightUnitId.present) {
       map['weight_unit_id'] = Variable<int>(weightUnitId.value);
     }
+    if (notes.present) {
+      map['notes'] = Variable<String>(notes.value);
+    }
     if (date.present) {
       map['date'] = Variable<DateTime>(
         $WorkoutLogTableTable.$converterdate.toSql(date.value),
@@ -6230,6 +6260,7 @@ class WorkoutLogTableCompanion extends UpdateCompanion<Log> {
           ..write('weight: $weight, ')
           ..write('weightTarget: $weightTarget, ')
           ..write('weightUnitId: $weightUnitId, ')
+          ..write('notes: $notes, ')
           ..write('date: $date, ')
           ..write('rowid: $rowid')
           ..write(')'))
@@ -17265,6 +17296,7 @@ typedef $$WorkoutLogTableTableCreateCompanionBuilder =
       Value<double?> weight,
       Value<double?> weightTarget,
       Value<int?> weightUnitId,
+      Value<String?> notes,
       required DateTime date,
       Value<int> rowid,
     });
@@ -17284,6 +17316,7 @@ typedef $$WorkoutLogTableTableUpdateCompanionBuilder =
       Value<double?> weight,
       Value<double?> weightTarget,
       Value<int?> weightUnitId,
+      Value<String?> notes,
       Value<DateTime> date,
       Value<int> rowid,
     });
@@ -17366,6 +17399,9 @@ class $$WorkoutLogTableTableFilterComposer
     column: $table.weightUnitId,
     builder: (column) => ColumnFilters(column),
   );
+
+  ColumnFilters<String> get notes =>
+      $composableBuilder(column: $table.notes, builder: (column) => ColumnFilters(column));
 
   ColumnWithTypeConverterFilters<DateTime, DateTime, DateTime> get date => $composableBuilder(
     column: $table.date,
@@ -17452,6 +17488,9 @@ class $$WorkoutLogTableTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<String> get notes =>
+      $composableBuilder(column: $table.notes, builder: (column) => ColumnOrderings(column));
+
   ColumnOrderings<DateTime> get date => $composableBuilder(
     column: $table.date,
     builder: (column) => ColumnOrderings(column),
@@ -17523,6 +17562,9 @@ class $$WorkoutLogTableTableAnnotationComposer
     builder: (column) => column,
   );
 
+  GeneratedColumn<String> get notes =>
+      $composableBuilder(column: $table.notes, builder: (column) => column);
+
   GeneratedColumnWithTypeConverter<DateTime, DateTime> get date =>
       $composableBuilder(column: $table.date, builder: (column) => column);
 }
@@ -17574,6 +17616,7 @@ class $$WorkoutLogTableTableTableManager
                 Value<double?> weight = const Value.absent(),
                 Value<double?> weightTarget = const Value.absent(),
                 Value<int?> weightUnitId = const Value.absent(),
+                Value<String?> notes = const Value.absent(),
                 Value<DateTime> date = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
               }) => WorkoutLogTableCompanion(
@@ -17591,6 +17634,7 @@ class $$WorkoutLogTableTableTableManager
                 weight: weight,
                 weightTarget: weightTarget,
                 weightUnitId: weightUnitId,
+                notes: notes,
                 date: date,
                 rowid: rowid,
               ),
@@ -17610,6 +17654,7 @@ class $$WorkoutLogTableTableTableManager
                 Value<double?> weight = const Value.absent(),
                 Value<double?> weightTarget = const Value.absent(),
                 Value<int?> weightUnitId = const Value.absent(),
+                Value<String?> notes = const Value.absent(),
                 required DateTime date,
                 Value<int> rowid = const Value.absent(),
               }) => WorkoutLogTableCompanion.insert(
@@ -17627,6 +17672,7 @@ class $$WorkoutLogTableTableTableManager
                 weight: weight,
                 weightTarget: weightTarget,
                 weightUnitId: weightUnitId,
+                notes: notes,
                 date: date,
                 rowid: rowid,
               ),

--- a/lib/database/powersync/tables/routines.dart
+++ b/lib/database/powersync/tables/routines.dart
@@ -80,6 +80,7 @@ class WorkoutLogTable extends Table {
   RealColumn get weight => real().nullable()();
   RealColumn get weightTarget => real().nullable().named('weight_target')();
   IntColumn get weightUnitId => integer().nullable().named('weight_unit_id')();
+  TextColumn get notes => text().nullable()();
 
   DateTimeColumn get date => dateTime().map(const UtcDateTimeConverter())();
 }
@@ -100,6 +101,7 @@ const PowersyncWorkoutLogTable = ps.Table(
     ps.Column.real('weight'),
     ps.Column.real('weight_target'),
     ps.Column.integer('weight_unit_id'),
+    ps.Column.text('notes'),
     ps.Column.text('date'),
   ],
   indexes: [

--- a/lib/features/routines/models/log.dart
+++ b/lib/features/routines/models/log.dart
@@ -70,6 +70,8 @@ class Log {
   num? rir;
   num? rirTarget;
 
+  String? notes;
+
   num? repetitions;
   num? repetitionsTarget;
   int? repetitionsUnitId;
@@ -95,6 +97,7 @@ class Log {
     this.repetitionsUnitObj,
     this.rir,
     this.rirTarget,
+    this.notes,
     this.weight,
     this.weightTarget,
     this.weightUnitId = WEIGHT_UNIT_KG,
@@ -134,6 +137,7 @@ class Log {
     int? slotEntryId,
     num? rir,
     num? rirTarget,
+    String? notes,
     num? repetitions,
     num? repetitionsTarget,
     int? repetitionsUnitId,
@@ -157,6 +161,7 @@ class Log {
       repetitionsUnitObj: repetitionsUnitObj ?? this.repetitionsUnitObj,
       rir: rir ?? this.rir,
       rirTarget: rirTarget ?? this.rirTarget,
+      notes: notes ?? this.notes,
       weight: weight ?? this.weight,
       weightTarget: weightTarget ?? this.weightTarget,
       weightUnitId: weightUnitId ?? this.weightUnitId,
@@ -208,6 +213,7 @@ class Log {
           ? drift.Value(weightTarget!.toDouble())
           : const drift.Value.absent(),
       weightUnitId: weightUnitId != null ? drift.Value(weightUnitId) : const drift.Value.absent(),
+      notes: notes != null ? drift.Value(notes) : const drift.Value.absent(),
       date: drift.Value(date),
     );
   }

--- a/lib/features/routines/providers/gym_log_notifier.dart
+++ b/lib/features/routines/providers/gym_log_notifier.dart
@@ -66,4 +66,10 @@ class GymLogNotifier extends _$GymLogNotifier {
   void setWeightUnit(WeightUnit weightUnit) {
     state = state?.copyWith(weightUnitObj: weightUnit);
   }
+
+  void setNotes(String notes) {
+    if (state != null) {
+      state = state!..notes = notes;
+    }
+  }
 }

--- a/lib/features/routines/widgets/gym_mode/log_page.dart
+++ b/lib/features/routines/widgets/gym_mode/log_page.dart
@@ -265,7 +265,11 @@ class LogsPastLogsWidget extends ConsumerWidget {
             return ListTile(
               key: ValueKey('past-log-${pastLog.id}'),
               title: Text(pastLog.repTextNoNl(context)),
-              subtitle: Text(dateFormat.format(pastLog.date)),
+              subtitle: Text(
+                pastLog.notes != null && pastLog.notes!.isNotEmpty
+                    ? '${dateFormat.format(pastLog.date)} · ${pastLog.notes}'
+                    : dateFormat.format(pastLog.date),
+              ),
               trailing: const Icon(Icons.copy),
               onTap: () {
                 logProvider.setLog(pastLog, exercise: exercise);
@@ -297,6 +301,13 @@ class LogFormWidget extends ConsumerStatefulWidget {
 
 class _LogFormWidgetState extends ConsumerState<LogFormWidget> {
   final _form = GlobalKey<FormState>();
+  final _notesController = TextEditingController();
+
+  @override
+  void dispose() {
+    _notesController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -366,6 +377,16 @@ class _LogFormWidgetState extends ConsumerState<LogFormWidget> {
             log.rir,
             onChanged: (value) {
               log.rir = value == '' ? null : num.parse(value);
+            },
+          ),
+          TextFormField(
+            key: const ValueKey('notes-input-widget'),
+            controller: _notesController,
+            decoration: InputDecoration(labelText: i18n.notes),
+            maxLines: 2,
+            keyboardType: TextInputType.multiline,
+            onChanged: (value) {
+              ref.read(gymLogProvider.notifier).setNotes(value);
             },
           ),
           FilledButton(

--- a/lib/features/routines/widgets/logs/log_edit_dialog.dart
+++ b/lib/features/routines/widgets/logs/log_edit_dialog.dart
@@ -68,6 +68,7 @@ class _LogEditDialogState extends ConsumerState<LogEditDialog> {
   num? _rir;
   RepetitionUnit? _repetitionUnit;
   WeightUnit? _weightUnit;
+  late TextEditingController _notesController;
 
   bool _saving = false;
 
@@ -79,6 +80,13 @@ class _LogEditDialogState extends ConsumerState<LogEditDialog> {
     _rir = widget.log.rir;
     _repetitionUnit = widget.log.repetitionsUnitObj;
     _weightUnit = widget.log.weightUnitObj;
+    _notesController = TextEditingController(text: widget.log.notes ?? '');
+  }
+
+  @override
+  void dispose() {
+    _notesController.dispose();
+    super.dispose();
   }
 
   Future<void> _onSave() async {
@@ -101,12 +109,14 @@ class _LogEditDialogState extends ConsumerState<LogEditDialog> {
 
     setState(() => _saving = true);
 
+    final notes = _notesController.text.trim();
     final updated = widget.log.copyWith(
       repetitions: _repetitions,
       weight: _weight,
       rir: _rir,
       repetitionsUnitObj: _repetitionUnit,
       weightUnitObj: _weightUnit,
+      notes: notes.isEmpty ? null : notes,
     );
 
     try {
@@ -166,6 +176,16 @@ class _LogEditDialogState extends ConsumerState<LogEditDialog> {
                 onChanged: (v) => setState(() {
                   _rir = v.isEmpty ? null : num.parse(v);
                 }),
+              ),
+              const SizedBox(height: 12),
+              TextFormField(
+                key: const ValueKey('edit-notes-widget'),
+                controller: _notesController,
+                decoration: InputDecoration(
+                  labelText: AppLocalizations.of(context).notes,
+                ),
+                maxLines: 2,
+                keyboardType: TextInputType.multiline,
               ),
             ],
           ),

--- a/test/features/routines/models/log_test.dart
+++ b/test/features/routines/models/log_test.dart
@@ -254,6 +254,74 @@ void main() {
     });
   });
 
+  group('Log notes field', () {
+    test('defaults to null when not provided', () {
+      final log = Log(exerciseId: 1, weight: 50, repetitions: 10, rir: null);
+      expect(log.notes, isNull);
+    });
+
+    test('is set when provided to constructor', () {
+      final log = Log(
+        exerciseId: 1,
+        weight: 50,
+        repetitions: 10,
+        rir: null,
+        notes: 'Felt strong today',
+      );
+      expect(log.notes, 'Felt strong today');
+    });
+
+    test('copyWith preserves notes when not overridden', () {
+      final log = Log(
+        exerciseId: 1,
+        weight: 50,
+        repetitions: 10,
+        rir: null,
+        notes: 'Original note',
+      );
+      final copy = log.copyWith(weight: 60);
+      expect(copy.notes, 'Original note');
+    });
+
+    test('copyWith updates notes when provided', () {
+      final log = Log(
+        exerciseId: 1,
+        weight: 50,
+        repetitions: 10,
+        rir: null,
+        notes: 'Original note',
+      );
+      final copy = log.copyWith(notes: 'Updated note');
+      expect(copy.notes, 'Updated note');
+    });
+
+    test('toCompanion includes notes when set', () {
+      final log = Log(
+        exerciseId: 1,
+        weight: 50,
+        repetitions: 10,
+        rir: null,
+        date: DateTime.utc(2026, 1, 1),
+        notes: 'Test note',
+      );
+      final companion = log.toCompanion();
+      expect(companion.notes.present, isTrue);
+      expect(companion.notes.value, 'Test note');
+    });
+
+    test('toCompanion omits notes when null', () {
+      final log = Log(
+        exerciseId: 1,
+        weight: 50,
+        repetitions: 10,
+        rir: null,
+        date: DateTime.utc(2026, 1, 1),
+      );
+      final companion = log.toCompanion();
+      expect(companion.notes.present, isFalse);
+    });
+  });
+
   group('Test the workout log model', () {
     late Log log1;
     late Log log2;

--- a/test/features/routines/providers/workout_logs_repository_test.dart
+++ b/test/features/routines/providers/workout_logs_repository_test.dart
@@ -373,4 +373,58 @@ void main() {
       await sub.cancel();
     });
   });
+
+  group('notes field', () {
+    test('persists notes through the database round-trip', () async {
+      await seedUnits();
+      final log = Log(
+        exerciseId: 1,
+        routineId: 100,
+        weight: 80,
+        repetitions: 5,
+        date: DateTime.utc(2026, 4, 15),
+        notes: 'Heavy day, form felt good',
+      );
+
+      await db.into(db.workoutLogTable).insert(log.toCompanion());
+
+      final rows = await readLogs();
+      expect(rows, hasLength(1));
+      expect(rows.first.notes, 'Heavy day, form felt good');
+    });
+
+    test('stores null notes when not provided', () async {
+      await seedUnits();
+      final log = Log(
+        exerciseId: 1,
+        routineId: 100,
+        weight: 80,
+        repetitions: 5,
+        date: DateTime.utc(2026, 4, 15),
+      );
+
+      await db.into(db.workoutLogTable).insert(log.toCompanion());
+
+      final rows = await readLogs();
+      expect(rows.first.notes, isNull);
+    });
+
+    test('addLocalDrift persists notes', () async {
+      await seedUnits();
+      final log = Log(
+        exerciseId: 1,
+        routineId: 100,
+        sessionId: 'session-1',
+        weight: 80,
+        repetitions: 5,
+        date: DateTime.utc(2026, 4, 15),
+        notes: 'PR attempt',
+      );
+
+      await repo.addLocalDrift(log);
+
+      final rows = await readLogs();
+      expect(rows.first.notes, 'PR attempt');
+    });
+  });
 }


### PR DESCRIPTION
Companion to wger-project/wger#2462 and wger-project/react#1289.
Adds the new optional `notes` field to the Flutter workout log, mirroring
the Django and React changes.

<!-- Thank you for contributing! If you want to suggest a new feature, please -->
<!-- discuss it first, either by opening a new issue, asking on an existing   -->
<!-- one, or on discord. -->

# Proposed Changes

- `WorkoutLogTable` + `PowersyncWorkoutLogTable`: add nullable `notes` text column
- `Log` model: `notes` field with constructor param, `copyWith`, and `toCompanion`
- `GymLogNotifier`: add `setNotes()` method
- Gym mode log entry form: notes text field
- Past logs list: notes shown inline in subtitle when present
- Log edit dialog: notes text field, persisted on save

**Note:** `database.g.dart` was hand-updated (Flutter not available in dev
environment). Recommend running `dart run build_runner build` to verify the
generated output is identical.

## Related Issue(s)

<!-- If applicable, please link to any related issues "Closes #123", -->
<!-- "Closes wger-project/other-repo#123", "See also #123", etc.      -->

## Please check that the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Set a 100-character limit to avoid white space diffs (run `dart format .`)
