### PR TITLE
fix(auth): do not await PowerSync disconnect during session clear

### DIFF
--- a/lib/core/network/auth_notifier.dart
+++ b/lib/core/network/auth_notifier.dart
@@ -94,6 +94,12 @@ class AuthNotifier extends _$AuthNotifier {
   @visibleForTesting
   int userSwitchWipeCount = 0;
 
+  /// Stops the PowerSync sync loop on the keep-data session-reset path.
+  /// Injectable because `PowerSyncDatabase` is a `base` class and cannot be
+  /// faked in tests.
+  @visibleForTesting
+  Future<void> Function() disconnectPowerSync = _disconnectBuiltPowerSync;
+
   @override
   Future<AuthState> build() async {
     _client = ref.read(authHttpClientProvider);
@@ -906,9 +912,10 @@ class AuthNotifier extends _$AuthNotifier {
   /// [logout] instead, which performs a full wipe.
   Future<void> clearSessionOnly() => _resetSession(wipeLocalData: false, sessionExpired: true);
 
-  /// Shared body for [logout] and [clearSessionOnly]. PowerSync is touched
-  /// before the state mutation so a reader observing the post-reset state
-  /// can never race ahead and re-attach to a DB we're about to wipe.
+  /// Shared body for [logout] and [clearSessionOnly]. On the wipe path
+  /// PowerSync is touched before the state mutation so a reader observing the
+  /// post-reset state can never race ahead and re-attach to a DB we're about
+  /// to wipe.
   ///
   /// [sessionExpired] marks the reset as involuntary in the published state,
   /// so the login screen can tell the user why they were logged out.
@@ -927,7 +934,11 @@ class AuthNotifier extends _$AuthNotifier {
         wiped = false;
       }
     } else {
-      await _disconnectPowerSyncIfBuilt();
+      // Deliberately not awaited: this path runs inside the single-flight
+      // refresh future, and the disconnect can block on a sync fetch that is
+      // itself awaiting that future (refresh -> disconnect -> sync fetch ->
+      // refresh deadlock). The DB is kept, so there is no wipe to race with.
+      unawaited(disconnectPowerSync());
     }
 
     state = AsyncData(
@@ -946,21 +957,6 @@ class AuthNotifier extends _$AuthNotifier {
       }
     } else {
       await _storage.clearCredentials();
-    }
-  }
-
-  /// Disconnects an already-built PowerSync DB but keeps its data on
-  /// disk so a subsequent login can re-attach to the same database.
-  /// No-op when PowerSync hasn't been built yet.
-  Future<void> _disconnectPowerSyncIfBuilt() async {
-    final db = builtPowerSyncInstance;
-    if (db == null) {
-      return;
-    }
-    try {
-      await db.disconnect();
-    } catch (e, s) {
-      _logger.warning('PowerSync disconnect failed', e, s);
     }
   }
 
@@ -1037,6 +1033,21 @@ class AuthNotifier extends _$AuthNotifier {
 /// [JwtCredential] (fresh logins go through `allauth.headless`); the refresh
 /// token is the one the caller still needs to write to secure storage.
 typedef _FreshCredentials = ({JwtCredential credential, String? refreshToken});
+
+/// Default for [AuthNotifier.disconnectPowerSync]: disconnects an
+/// already-built PowerSync DB but keeps its data on disk. No-op when
+/// PowerSync hasn't been built yet.
+Future<void> _disconnectBuiltPowerSync() async {
+  final db = builtPowerSyncInstance;
+  if (db == null) {
+    return;
+  }
+  try {
+    await db.disconnect();
+  } catch (e, s) {
+    Logger('AuthNotifier').warning('PowerSync disconnect failed', e, s);
+  }
+}
 
 /// User-agent header string identifying the app/version/platform.
 String getAppNameHeader(PackageInfo? applicationVersion) {

--- a/test/core/network/auth_notifier_powersync_test.dart
+++ b/test/core/network/auth_notifier_powersync_test.dart
@@ -1244,6 +1244,34 @@ void main() {
       expect(await PreferenceHelper.asyncPref.getBool(PREFS_HAS_EVER_SYNCED), true);
     });
 
+    test('rejected refresh completes even when the PowerSync disconnect hangs', () async {
+      // Regression test for a deadlock: the disconnect can block on a sync
+      // fetch that awaits this same single-flight refresh, so the session
+      // reset must not await it. The refresh must finish and clear the
+      // session even when the disconnect never completes.
+      await PreferenceHelper.asyncPref.setBool(PREFS_HAS_EVER_SYNCED, true);
+      when(mockSecureStorage.readRefreshToken()).thenAnswer((_) async => 'old-refresh');
+      when(
+        mockClient.post(tRefresh, headers: anyNamed('headers'), body: anyNamed('body')),
+      ).thenAnswer((_) async => Response('Bad Request', 400));
+
+      final container = makeContainer();
+      await container.read(authProvider.future);
+
+      var disconnectCalls = 0;
+      final notifier = container.read(authProvider.notifier);
+      notifier.disconnectPowerSync = () {
+        disconnectCalls++;
+        return Completer<void>().future; // never completes
+      };
+
+      // Before the fix this future never completed.
+      await notifier.refreshAccessToken().timeout(const Duration(seconds: 5));
+
+      expect(container.read(authProvider).value!.status, AuthStatus.loggedOut);
+      expect(disconnectCalls, 1);
+    });
+
     test('network error → stays logged in', () async {
       // Pure offline case: we cannot conclude anything about the validity of
       // the refresh token, so keep the session intact and let the user keep


### PR DESCRIPTION
# Proposed Changes

- Stop awaiting the PowerSync disconnect in the keep-data session reset
  (clearSessionOnly). The await closes a three-party circular wait when a
  refresh token is rejected: the refresh future runs the session teardown,
  the teardown awaits PowerSync's disconnect, the disconnect waits for the
  in-flight sync fetch to abort, and that fetch is awaiting the same
  single-flight refresh future through AuthHttpClient's pre-emptive refresh.
  The refresh future then never completes and every later authenticated
  request queues behind it forever (15 second timeouts on every endpoint,
  surviving app restarts). See the issue for the full production diagnosis.
- The disconnect is now fire-and-forget on this path. The DB is deliberately
  kept, so there is no wipe to race with: once the cleared state is
  published, the wedged sync fetch resumes without a credential, gets a 401
  and PowerSync backs off, letting the deferred disconnect finish. The wipe
  path (explicit logout) keeps its wipe-before-publish ordering.
- Make the disconnect hook injectable (visibleForTesting field) so the
  regression test can install a never-completing disconnect;
  PowerSyncDatabase is a base class and cannot be faked directly.
- Add a regression test: a rejected refresh must complete and publish the
  logged-out state even when the PowerSync disconnect hangs forever.

## Related Issue(s)

Closes #1312

## Checklist

- [x] Tests pass locally (flutter test, 1235 tests)
- [x] flutter analyze reports no issues on the changed files
- [x] New behaviour is covered by a regression test
