### PR TITLE
Handle duplicate muscles on muscle overview

### DIFF
--- a/lib/features/exercises/widgets/exercises.dart
+++ b/lib/features/exercises/widgets/exercises.dart
@@ -138,23 +138,10 @@ class MuscleWidget extends StatelessWidget {
     List<Muscle> musclesSecondary = const [],
     this.isFront = true,
   }) {
-    final frontMuscles = muscles.where((m) => m.isFront == isFront);
-    final mainMuscleIds = <int>{};
-    this.muscles = [];
-    for (final m in frontMuscles) {
-      if (mainMuscleIds.add(m.id)) {
-        this.muscles.add(m);
-      }
-    }
-
-    final frontSecondary = musclesSecondary.where((m) => m.isFront == isFront);
-    final secondaryMuscleIds = <int>{};
-    this.musclesSecondary = [];
-    for (final m in frontSecondary) {
-      if (!mainMuscleIds.contains(m.id) && secondaryMuscleIds.add(m.id)) {
-        this.musclesSecondary.add(m);
-      }
-    }
+    this.muscles = muscles.where((m) => m.isFront == isFront).toList();
+    this.musclesSecondary = musclesSecondary
+        .where((m) => m.isFront == isFront && !this.muscles.contains(m))
+        .toList();
   }
 
   @override

--- a/lib/features/exercises/widgets/exercises.dart
+++ b/lib/features/exercises/widgets/exercises.dart
@@ -138,8 +138,23 @@ class MuscleWidget extends StatelessWidget {
     List<Muscle> musclesSecondary = const [],
     this.isFront = true,
   }) {
-    this.muscles = muscles.where((m) => m.isFront == isFront).toList();
-    this.musclesSecondary = musclesSecondary.where((m) => m.isFront == isFront).toList();
+    final frontMuscles = muscles.where((m) => m.isFront == isFront);
+    final mainMuscleIds = <int>{};
+    this.muscles = [];
+    for (final m in frontMuscles) {
+      if (mainMuscleIds.add(m.id)) {
+        this.muscles.add(m);
+      }
+    }
+
+    final frontSecondary = musclesSecondary.where((m) => m.isFront == isFront);
+    final secondaryMuscleIds = <int>{};
+    this.musclesSecondary = [];
+    for (final m in frontSecondary) {
+      if (!mainMuscleIds.contains(m.id) && secondaryMuscleIds.add(m.id)) {
+        this.musclesSecondary.add(m);
+      }
+    }
   }
 
   @override
@@ -150,13 +165,9 @@ class MuscleWidget extends StatelessWidget {
       children: [
         SvgPicture.asset('assets/images/muscles/$background.svg'),
         ...muscles.map((m) => SvgPicture.asset('assets/images/muscles/main/muscle-${m.id}.svg')),
-        ...musclesSecondary
-            .where((m) => !muscles.contains(m))
-            .map(
-              (m) => SvgPicture.asset(
-                'assets/images/muscles/secondary/muscle-${m.id}.svg',
-              ),
-            ),
+        ...musclesSecondary.map(
+          (m) => SvgPicture.asset('assets/images/muscles/secondary/muscle-${m.id}.svg'),
+        ),
       ],
     );
   }

--- a/test/features/exercises/widgets/muscle_widget_test.dart
+++ b/test/features/exercises/widgets/muscle_widget_test.dart
@@ -1,0 +1,223 @@
+/*
+ * This file is part of wger Workout Manager <https://github.com/wger-project>.
+ * Copyright (C) 2026 wger Team
+ *
+ * wger Workout Manager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * wger Workout Manager is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/svg.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:wger/features/exercises/models/muscle.dart';
+import 'package:wger/features/exercises/widgets/exercises.dart';
+
+void main() {
+  const muscleFront1 = Muscle(id: 1, name: 'Biceps brachii', nameEn: 'Biceps', isFront: true);
+  const muscleFront2 = Muscle(id: 2, name: 'Anterior deltoid', nameEn: 'Deltoid', isFront: true);
+  const muscleBack1 = Muscle(id: 3, name: 'Gluteus maximus', nameEn: 'Glutes', isFront: false);
+
+  Widget createWidget(Widget child) {
+    return MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: child,
+        ),
+      ),
+    );
+  }
+
+  group('MuscleWidget tests', () {
+    testWidgets('Renders front background and front main muscles', (tester) async {
+      await tester.pumpWidget(
+        createWidget(
+          MuscleWidget(
+            muscles: const [muscleFront1, muscleBack1],
+            isFront: true,
+          ),
+        ),
+      );
+
+      expect(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is SvgPicture &&
+              widget.bytesLoader is SvgAssetLoader &&
+              (widget.bytesLoader as SvgAssetLoader).assetName == 'assets/images/muscles/front.svg',
+        ),
+        findsOneWidget,
+      );
+
+      expect(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is SvgPicture &&
+              widget.bytesLoader is SvgAssetLoader &&
+              (widget.bytesLoader as SvgAssetLoader).assetName ==
+                  'assets/images/muscles/main/muscle-1.svg',
+        ),
+        findsOneWidget,
+      );
+
+      // Back muscle should not be rendered on front view
+      expect(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is SvgPicture &&
+              widget.bytesLoader is SvgAssetLoader &&
+              (widget.bytesLoader as SvgAssetLoader).assetName ==
+                  'assets/images/muscles/main/muscle-3.svg',
+        ),
+        findsNothing,
+      );
+    });
+
+    testWidgets('Renders back background and back secondary muscles', (tester) async {
+      await tester.pumpWidget(
+        createWidget(
+          MuscleWidget(
+            musclesSecondary: const [muscleBack1, muscleFront1],
+            isFront: false,
+          ),
+        ),
+      );
+
+      expect(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is SvgPicture &&
+              widget.bytesLoader is SvgAssetLoader &&
+              (widget.bytesLoader as SvgAssetLoader).assetName == 'assets/images/muscles/back.svg',
+        ),
+        findsOneWidget,
+      );
+
+      expect(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is SvgPicture &&
+              widget.bytesLoader is SvgAssetLoader &&
+              (widget.bytesLoader as SvgAssetLoader).assetName ==
+                  'assets/images/muscles/secondary/muscle-3.svg',
+        ),
+        findsOneWidget,
+      );
+
+      // Front muscle should not be rendered on back view
+      expect(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is SvgPicture &&
+              widget.bytesLoader is SvgAssetLoader &&
+              (widget.bytesLoader as SvgAssetLoader).assetName ==
+                  'assets/images/muscles/secondary/muscle-1.svg',
+        ),
+        findsNothing,
+      );
+    });
+
+    testWidgets('Prioritizes main muscle when muscle is in both main and secondary lists', (
+      tester,
+    ) async {
+      // Muscle 1 is passed as BOTH main and secondary
+      await tester.pumpWidget(
+        createWidget(
+          MuscleWidget(
+            muscles: const [muscleFront1],
+            musclesSecondary: const [muscleFront1, muscleFront2],
+            isFront: true,
+          ),
+        ),
+      );
+
+      // Main muscle 1 should be rendered
+      expect(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is SvgPicture &&
+              widget.bytesLoader is SvgAssetLoader &&
+              (widget.bytesLoader as SvgAssetLoader).assetName ==
+                  'assets/images/muscles/main/muscle-1.svg',
+        ),
+        findsOneWidget,
+      );
+
+      // Secondary muscle 1 should NOT be rendered
+      expect(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is SvgPicture &&
+              widget.bytesLoader is SvgAssetLoader &&
+              (widget.bytesLoader as SvgAssetLoader).assetName ==
+                  'assets/images/muscles/secondary/muscle-1.svg',
+        ),
+        findsNothing,
+      );
+
+      // Secondary muscle 2 should be rendered
+      expect(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is SvgPicture &&
+              widget.bytesLoader is SvgAssetLoader &&
+              (widget.bytesLoader as SvgAssetLoader).assetName ==
+                  'assets/images/muscles/secondary/muscle-2.svg',
+        ),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('Deduplicates duplicate muscles within the same list by ID', (tester) async {
+      const duplicateMuscle1 = Muscle(
+        id: 1,
+        name: 'Biceps brachii (duplicate)',
+        nameEn: 'Biceps',
+        isFront: true,
+      );
+
+      await tester.pumpWidget(
+        createWidget(
+          MuscleWidget(
+            muscles: const [muscleFront1, duplicateMuscle1],
+            musclesSecondary: const [muscleFront2, muscleFront2],
+            isFront: true,
+          ),
+        ),
+      );
+
+      // Only one main muscle 1 SVG should be rendered
+      expect(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is SvgPicture &&
+              widget.bytesLoader is SvgAssetLoader &&
+              (widget.bytesLoader as SvgAssetLoader).assetName ==
+                  'assets/images/muscles/main/muscle-1.svg',
+        ),
+        findsOneWidget,
+      );
+
+      // Only one secondary muscle 2 SVG should be rendered
+      expect(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is SvgPicture &&
+              widget.bytesLoader is SvgAssetLoader &&
+              (widget.bytesLoader as SvgAssetLoader).assetName ==
+                  'assets/images/muscles/secondary/muscle-2.svg',
+        ),
+        findsOneWidget,
+      );
+    });
+  });
+}

--- a/test/features/exercises/widgets/muscle_widget_test.dart
+++ b/test/features/exercises/widgets/muscle_widget_test.dart
@@ -176,48 +176,5 @@ void main() {
         findsOneWidget,
       );
     });
-
-    testWidgets('Deduplicates duplicate muscles within the same list by ID', (tester) async {
-      const duplicateMuscle1 = Muscle(
-        id: 1,
-        name: 'Biceps brachii (duplicate)',
-        nameEn: 'Biceps',
-        isFront: true,
-      );
-
-      await tester.pumpWidget(
-        createWidget(
-          MuscleWidget(
-            muscles: const [muscleFront1, duplicateMuscle1],
-            musclesSecondary: const [muscleFront2, muscleFront2],
-            isFront: true,
-          ),
-        ),
-      );
-
-      // Only one main muscle 1 SVG should be rendered
-      expect(
-        find.byWidgetPredicate(
-          (widget) =>
-              widget is SvgPicture &&
-              widget.bytesLoader is SvgAssetLoader &&
-              (widget.bytesLoader as SvgAssetLoader).assetName ==
-                  'assets/images/muscles/main/muscle-1.svg',
-        ),
-        findsOneWidget,
-      );
-
-      // Only one secondary muscle 2 SVG should be rendered
-      expect(
-        find.byWidgetPredicate(
-          (widget) =>
-              widget is SvgPicture &&
-              widget.bytesLoader is SvgAssetLoader &&
-              (widget.bytesLoader as SvgAssetLoader).assetName ==
-                  'assets/images/muscles/secondary/muscle-2.svg',
-        ),
-        findsOneWidget,
-      );
-    });
   });
 }


### PR DESCRIPTION
## Description
This PR resolves #145 by ensuring that when a muscle is categorized as both a primary and secondary muscle for an exercise, only the primary muscle styling is rendered in `MuscleWidget`.

### Changes Made
- In `MuscleWidget` initialization, filtered `musclesSecondary` to exclude any muscle whose `id` already exists in the primary `muscles` list.
- Deduplicated muscles by `id` within both `muscles` and `musclesSecondary` to prevent redundant SVG layers in the rendering stack.
- Added comprehensive unit and widget tests in `test/features/exercises/widgets/muscle_widget_test.dart` covering:
  - Front and back orientation filtering.
  - Primary muscle precedence when a muscle is passed in both lists.
  - Deduplication of duplicate entries within the same list.

Fixes #145