### PR TITLE
Prepare iOS health release requirements

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1,6 +1,54 @@
 import Flutter
 import UIKit
 
+private final class StorageExclusionPlugin: NSObject, FlutterPlugin {
+  static let pluginName = "StorageExclusionPlugin"
+  private static let channelName = "de.wger.flutter/storage"
+
+  static func register(with registrar: FlutterPluginRegistrar) {
+    let channel = FlutterMethodChannel(name: channelName, binaryMessenger: registrar.messenger())
+    let instance = StorageExclusionPlugin()
+    registrar.addMethodCallDelegate(instance, channel: channel)
+  }
+
+  func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+    guard call.method == "excludeFromBackup" else {
+      result(FlutterMethodNotImplemented)
+      return
+    }
+    guard
+      let arguments = call.arguments as? [String: Any],
+      let path = arguments["path"] as? String,
+      !path.isEmpty
+    else {
+      result(
+        FlutterError(
+          code: "INVALID_ARGUMENT",
+          message: "Expected a non-empty path",
+          details: nil
+        )
+      )
+      return
+    }
+
+    do {
+      var url = URL(fileURLWithPath: path)
+      var values = URLResourceValues()
+      values.isExcludedFromBackup = true
+      try url.setResourceValues(values)
+      result(nil)
+    } catch {
+      result(
+        FlutterError(
+          code: "EXCLUDE_FROM_BACKUP_FAILED",
+          message: "Could not exclude \(path) from backups",
+          details: error.localizedDescription
+        )
+      )
+    }
+  }
+}
+
 @main
 @objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
   override func application(
@@ -12,5 +60,8 @@ import UIKit
 
   func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
     GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
+    StorageExclusionPlugin.register(
+      with: engineBridge.pluginRegistry.registrar(forPlugin: StorageExclusionPlugin.pluginName)
+    )
   }
 }

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -60,8 +60,14 @@ private final class StorageExclusionPlugin: NSObject, FlutterPlugin {
 
   func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
     GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
-    StorageExclusionPlugin.register(
-      with: engineBridge.pluginRegistry.registrar(forPlugin: StorageExclusionPlugin.pluginName)
-    )
+    guard
+      let registrar = engineBridge.pluginRegistry.registrar(
+        forPlugin: StorageExclusionPlugin.pluginName
+      )
+    else {
+      NSLog("StorageExclusionPlugin registrar unavailable")
+      return
+    }
+    StorageExclusionPlugin.register(with: registrar)
   }
 }

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -88,7 +88,7 @@
 		<key>NSCameraUsageDescription</key>
 		<string>Workout photos</string>
 		<key>NSHealthShareUsageDescription</key>
-		<string>wger reads your health data to automatically import body measurements such as weight, body fat, blood pressure, heart rate and blood oxygen</string>
+		<string>wger reads your Apple Health data to import measurements and activity such as weight, body fat, blood pressure, heart rate, blood oxygen, sleep, steps, distance, and active energy into your wger account</string>
 		<key>UIApplicationSceneManifest</key>
 		<dict>
 			<key>UIApplicationSupportsMultipleScenes</key>

--- a/lib/database/powersync/powersync.dart
+++ b/lib/database/powersync/powersync.dart
@@ -19,6 +19,7 @@
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:http/http.dart' as http;
 import 'package:logging/logging.dart';
@@ -40,6 +41,9 @@ import 'package:wger/powersync/sync_watchdog.dart';
 part 'powersync.g.dart';
 
 final _logger = Logger('powersync');
+const _storageChannel = MethodChannel('de.wger.flutter/storage');
+const _dbFilename = 'powersync-wger.db';
+const _iosDbDirectoryName = 'de.wger.flutter.community';
 
 PowerSyncDatabase? _builtInstance;
 
@@ -283,14 +287,47 @@ final syncStatus = Provider((ref) {
 });
 
 Future<String> _getDatabasePath() async {
-  const dbFilename = 'powersync-wger.db';
-
   // getApplicationSupportDirectory is not supported on Web
   if (kIsWeb) {
-    return dbFilename;
+    return _dbFilename;
   }
+
   final dir = await getApplicationSupportDirectory();
-  return join(dir.path, dbFilename);
+  if (!Platform.isIOS) {
+    return join(dir.path, _dbFilename);
+  }
+
+  final dbDir = Directory(join(dir.path, _iosDbDirectoryName));
+  await dbDir.create(recursive: true);
+  await _migrateLegacyIosDatabaseFiles(fromDirectory: dir, toDirectory: dbDir);
+  await _excludeFromBackup(dbDir.path);
+  return join(dbDir.path, _dbFilename);
+}
+
+Future<void> _migrateLegacyIosDatabaseFiles({
+  required Directory fromDirectory,
+  required Directory toDirectory,
+}) async {
+  for (final suffix in ['', '-wal', '-shm', '-journal']) {
+    final from = File(join(fromDirectory.path, '$_dbFilename$suffix'));
+    final to = File(join(toDirectory.path, '$_dbFilename$suffix'));
+
+    if (!from.existsSync() || to.existsSync()) {
+      continue;
+    }
+
+    await from.rename(to.path);
+  }
+}
+
+Future<void> _excludeFromBackup(String path) async {
+  try {
+    await _storageChannel.invokeMethod<void>('excludeFromBackup', {'path': path});
+  } on MissingPluginException {
+    _logger.warning('Could not exclude $path from backups: storage channel unavailable');
+  } on PlatformException catch (e, s) {
+    _logger.warning('Could not exclude $path from backups', e, s);
+  }
 }
 
 /// Deletes the on-disk PowerSync SQLite files (main DB plus WAL/SHM/journal

--- a/test/features/health/health_ios_release_prep_test.dart
+++ b/test/features/health/health_ios_release_prep_test.dart
@@ -1,0 +1,54 @@
+/*
+ * This file is part of wger Workout Manager <https://github.com/wger-project>.
+ * Copyright (c) 2026 wger Team
+ *
+ * wger Workout Manager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('iOS health release prep', () {
+    test('Info.plist describes the imported Health data scope', () {
+      final plist = File('ios/Runner/Info.plist').readAsStringSync();
+
+      expect(plist, contains('<key>NSHealthShareUsageDescription</key>'));
+      expect(plist, contains('Apple Health'));
+      expect(plist, contains('sleep, steps, distance, and active energy'));
+      expect(plist, contains('wger account'));
+    });
+
+    test('PowerSync DB setup excludes the iOS database directory from backups', () {
+      final databaseSetup = File('lib/database/powersync/powersync.dart').readAsStringSync();
+
+      expect(databaseSetup, contains("const _iosDbDirectoryName = 'de.wger.flutter.community';"));
+      expect(databaseSetup, contains("MethodChannel('de.wger.flutter/storage')"));
+      expect(databaseSetup, contains("await _excludeFromBackup(dbDir.path);"));
+      expect(
+        databaseSetup,
+        contains("await _migrateLegacyIosDatabaseFiles(fromDirectory: dir, toDirectory: dbDir);"),
+      );
+    });
+
+    test('AppDelegate exposes the backup-exclusion channel', () {
+      final appDelegate = File('ios/Runner/AppDelegate.swift').readAsStringSync();
+
+      expect(appDelegate, contains('de.wger.flutter/storage'));
+      expect(appDelegate, contains('excludeFromBackup'));
+      expect(appDelegate, contains('values.isExcludedFromBackup = true'));
+    });
+  });
+}

--- a/test/features/health/health_ios_release_prep_test.dart
+++ b/test/features/health/health_ios_release_prep_test.dart
@@ -36,10 +36,10 @@ void main() {
 
       expect(databaseSetup, contains("const _iosDbDirectoryName = 'de.wger.flutter.community';"));
       expect(databaseSetup, contains("MethodChannel('de.wger.flutter/storage')"));
-      expect(databaseSetup, contains("await _excludeFromBackup(dbDir.path);"));
+      expect(databaseSetup, contains('await _excludeFromBackup(dbDir.path);'));
       expect(
         databaseSetup,
-        contains("await _migrateLegacyIosDatabaseFiles(fromDirectory: dir, toDirectory: dbDir);"),
+        contains('await _migrateLegacyIosDatabaseFiles(fromDirectory: dir, toDirectory: dbDir);'),
       );
     });
 


### PR DESCRIPTION
# Proposed Changes

## Summary

- update the iOS HealthKit usage description to match the imported Apple Health data
- move the iOS PowerSync database into an app-specific Application Support subdirectory
- exclude the iOS PowerSync database directory from backups
- migrate legacy iOS PowerSync database files into the new directory
- add regression coverage for the iOS health release-prep changes

## Verification

- `flutter test test/features/health/health_manifest_test.dart test/features/health/health_ios_release_prep_test.dart`
- debug run on a physical iOS device succeeded
- verified the legacy DB migration path
- verified the backup exclusion method channel succeeds on-device

## Why

- Apple Health import adds health-related local data on iOS, so the local PowerSync SQLite store should not remain in a backup-eligible location.
- The HealthKit usage description now reflects the actual read scope used by the app, including activity and sleep-related imports in addition to body measurements.
- Existing iOS installs may already have a PowerSync DB in the legacy location, so the migration preserves local data across the update while moving the database into an excludable subdirectory.

# Related Issue(s)

Not applicable

# Please check that the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Set a 100-character limit to avoid white space diffs (run `dart format .`)