### PR TITLE
Add edit action to routine list items

### DIFF
--- a/lib/features/routines/widgets/routines_list.dart
+++ b/lib/features/routines/widgets/routines_list.dart
@@ -24,6 +24,7 @@ import 'package:wger/core/widgets/async_value_widget.dart';
 import 'package:wger/core/widgets/confirm_delete_dialog.dart';
 import 'package:wger/core/widgets/text_prompt.dart';
 import 'package:wger/features/routines/providers/routines_notifier.dart';
+import 'package:wger/features/routines/screens/routine_edit_screen.dart';
 import 'package:wger/features/routines/screens/routine_screen.dart';
 import 'package:wger/l10n/generated/app_localizations.dart';
 
@@ -98,6 +99,18 @@ class _RoutinesListState extends ConsumerState<RoutinesList> {
                   mainAxisSize: MainAxisSize.min,
                   children: [
                     if (!canOpen) const Icon(Icons.cloud_off),
+                    IconButton(
+                      icon: const Icon(Icons.edit),
+                      tooltip: AppLocalizations.of(context).edit,
+                      onPressed: canOpen
+                          ? () {
+                              Navigator.of(context).pushNamed(
+                                RoutineEditScreen.routeName,
+                                arguments: routineId,
+                              );
+                            }
+                          : null,
+                    ),
                     const VerticalDivider(),
                     if (_loadingRoutine == currentRoutine.id)
                       const IconButton(

--- a/test/features/routines/screens/routine_list_screen_test.dart
+++ b/test/features/routines/screens/routine_list_screen_test.dart
@@ -25,6 +25,7 @@ import 'package:wger/core/form_screen.dart';
 import 'package:wger/core/network/network_provider.dart';
 import 'package:wger/features/routines/models/routine.dart';
 import 'package:wger/features/routines/providers/routines_repository.dart';
+import 'package:wger/features/routines/screens/routine_edit_screen.dart';
 import 'package:wger/features/routines/screens/routine_list_screen.dart';
 import 'package:wger/features/routines/screens/routine_screen.dart';
 import 'package:wger/features/routines/widgets/forms/routine.dart';
@@ -80,6 +81,7 @@ void main() {
         routes: {
           FormScreen.routeName: (ctx) => const FormScreen(),
           RoutineScreen.routeName: (ctx) => const RoutineScreen(),
+          RoutineEditScreen.routeName: (ctx) => const Scaffold(body: Text('Edit Routine Screen')),
         },
       ),
     );
@@ -96,6 +98,30 @@ void main() {
     expect(find.text('test 2'), findsOneWidget);
     expect(find.byType(Card), findsNWidgets(2));
     expect(find.byType(ListTile), findsNWidgets(2));
+    expect(find.byIcon(Icons.edit), findsNWidgets(2));
+    expect(find.byIcon(Icons.delete), findsNWidgets(2));
+  });
+
+  testWidgets('Test the Edit button navigates to RoutineEditScreen', (WidgetTester tester) async {
+    await tester.pumpWidget(renderWidget());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byIcon(Icons.edit).first);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Edit Routine Screen'), findsOneWidget);
+  });
+
+  testWidgets('Edit button is disabled when offline and routine is not hydrated', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(renderWidget(isOnline: false));
+    await tester.pumpAndSettle();
+
+    final editButton = tester.widget<IconButton>(
+      find.widgetWithIcon(IconButton, Icons.edit).first,
+    );
+    expect(editButton.onPressed, isNull);
   });
 
   testWidgets('Test deleting an item using the Delete button', (WidgetTester tester) async {


### PR DESCRIPTION
## Description
This PR resolves #1275 by adding a direct edit action button to each routine card in the routines list screen.

### Changes Made
- Added an `IconButton` with `Icons.edit` immediately to the left of the `VerticalDivider` in `RoutinesList`.
- Tapping the edit button navigates directly to `RoutineEditScreen` with the corresponding routine ID.
- Ensured the edit button is properly enabled when the routine is accessible/hydrated and disabled when offline and not cached.
- Updated `routine_list_screen_test.dart` with tests verifying the edit action button appearance, navigation, and offline behavior.

Fixes #1275