### PR TITLE
Fix exercise video play icon staying visible during playback

### DIFF
--- a/lib/features/exercises/widgets/videos.dart
+++ b/lib/features/exercises/widgets/videos.dart
@@ -103,7 +103,15 @@ class _ExerciseVideoWidgetState extends ConsumerState<ExerciseVideoWidget> {
               alignment: Alignment.bottomCenter,
               children: [
                 VideoPlayer(controller),
-                _ControlsOverlay(controller: controller),
+                // Rebuild the overlay whenever the controller notifies (it is a
+                // ValueNotifier). Reading controller.value.isPlaying does not
+                // subscribe to changes, so without this the play icon never
+                // disappears once playback starts.
+                ValueListenableBuilder<VideoPlayerValue>(
+                  valueListenable: controller,
+                  builder: (context, value, child) =>
+                      _ControlsOverlay(controller: controller),
+                ),
                 VideoProgressIndicator(controller, allowScrubbing: true),
               ],
             ),


### PR DESCRIPTION
## Problem

When viewing an exercise video, tapping play starts playback (frames + audio advance) but the large central play-arrow overlay never disappears — it stays on top of the playing video, so you can't actually see the video.

## Cause

In `lib/features/exercises/widgets/videos.dart`, `_ControlsOverlay` decides whether to show the play icon from `controller.value.isPlaying`. But reading `.value` does **not** subscribe to the controller's notifications. `VideoPlayerController` is a `ValueNotifier<VideoPlayerValue>`: `play()` updates the value and notifies listeners, but nothing here listens, so the overlay is never rebuilt. `_ExerciseVideoWidgetState` only calls `setState()` after initialization/error, not on play/pause. The sibling `VideoPlayer` updating doesn't rebuild the overlay.

## Fix

Wrap `_ControlsOverlay` in a `ValueListenableBuilder` tied to the controller so it rebuilds on every controller notification. The `AnimatedSwitcher` then receives `SizedBox.shrink()` when playback starts and the icon animates away. This also keeps the playback-speed label current.

Minimal, one-widget change; no behavior change beyond the overlay now reacting to play/pause state.

## Notes

Reproduced on iOS. More visible on iOS since AVPlayer is stricter, but the missing-subscription bug is platform-independent.