### PR TITLE
Implement Double Progression and Rule Gating Support

### DIFF
--- a/lib/features/routines/models/requirement_rules.dart
+++ b/lib/features/routines/models/requirement_rules.dart
@@ -1,0 +1,67 @@
+// keep this list in sync with the backend `manager/consts.py`
+enum RequirementRule {
+  weight,
+  repetitions,
+  rir,
+  rest,
+  maxWeight,
+  maxRepetitions,
+}
+
+extension RequirementRuleParsing on RequirementRule {
+  String get apiValue {
+    switch (this) {
+      case RequirementRule.weight:
+        return 'weight';
+
+      case RequirementRule.repetitions:
+        return 'repetitions';
+
+      case RequirementRule.rir:
+        return 'rir';
+
+      case RequirementRule.rest:
+        return 'rest';
+
+      case RequirementRule.maxWeight:
+        return 'max_weight';
+
+      case RequirementRule.maxRepetitions:
+        return 'max_repetitions';
+    }
+  }
+
+  static RequirementRule? fromApiValue(String value) {
+    for (final rule in RequirementRule.values) {
+      if (rule.apiValue == value) {
+        return rule;
+      }
+    }
+    return null;
+  }
+}
+
+class ConfigRequirements {
+  final List<RequirementRule> rules;
+  final bool allSets;
+
+  const ConfigRequirements({required this.rules, required this.allSets});
+
+  static ConfigRequirements? fromMap(Map<String, dynamic>? requirements) {
+    if (requirements == null) {
+      return null;
+    }
+    final rawRules = (requirements['rules'] as List<dynamic>? ?? const [])
+        .whereType<String>()
+        .map(RequirementRuleParsing.fromApiValue)
+        .whereType<RequirementRule>()
+        .toList();
+    return ConfigRequirements(rules: rawRules, allSets: requirements['all_sets'] == true);
+  }
+
+  bool get isEmpty => rules.isEmpty;
+
+  bool get gatesOnMaxRepetitions => rules.contains(RequirementRule.maxRepetitions);
+
+  bool get gatesOnRepetitions => rules.contains(RequirementRule.repetitions);
+}

--- a/lib/features/routines/models/slot_entry.dart
+++ b/lib/features/routines/models/slot_entry.dart
@@ -235,7 +235,6 @@ class SlotEntry {
         maxRirConfigs.length > 1 ||
         restTimeConfigs.length > 1 ||
         maxRestTimeConfigs.length > 1 ||
-        maxWeightConfigs.length > 1 ||
         maxWeightConfigs.length > 1;
   }
 

--- a/lib/features/routines/widgets/forms/slot.dart
+++ b/lib/features/routines/widgets/forms/slot.dart
@@ -90,7 +90,10 @@ class _SlotDetailWidgetState extends ConsumerState<SlotDetailWidget> {
         errorMessage,
         ...widget.slot.entries.map(
           (entry) => entry.hasProgressionRules
-              ? ProgressionRulesInfoBox(entry.exerciseObj)
+              ? ProgressionRulesInfoBox(
+                  entry.exerciseObj,
+                  entry: entry,
+                )
               : SlotEntryForm(entry, widget.routineId, simpleMode: widget.simpleMode),
         ),
         const SizedBox(height: 10),

--- a/lib/features/routines/widgets/forms/slot_entry.dart
+++ b/lib/features/routines/widgets/forms/slot_entry.dart
@@ -389,7 +389,10 @@ class _SlotDetailWidgetState extends ConsumerState<SlotDetailWidget> {
         errorMessage,
         ...widget.slot.entries.map(
           (entry) => entry.hasProgressionRules
-              ? ProgressionRulesInfoBox(entry.exerciseObj)
+              ? ProgressionRulesInfoBox(
+                  entry.exerciseObj,
+                  entry: entry,
+                )
               : SlotEntryForm(entry, widget.routineId, simpleMode: widget.simpleMode),
         ),
         const SizedBox(height: 10),

--- a/lib/features/routines/widgets/slot.dart
+++ b/lib/features/routines/widgets/slot.dart
@@ -1,16 +1,68 @@
 import 'package:flutter/material.dart';
 import 'package:wger/features/exercises/models/exercise.dart';
+import 'package:wger/features/routines/models/base_config.dart';
+import 'package:wger/features/routines/models/requirement_rules.dart';
+import 'package:wger/features/routines/models/slot_entry.dart';
 import 'package:wger/l10n/generated/app_localizations.dart';
 
 class ProgressionRulesInfoBox extends StatelessWidget {
   final Exercise exercise;
+  final SlotEntry? entry;
 
-  const ProgressionRulesInfoBox(this.exercise, {super.key});
+  const ProgressionRulesInfoBox(this.exercise, {super.key, this.entry});
+
+  ConfigRequirements? _findActiveRequirements(SlotEntry entry) {
+    final allConfigLists = <List<BaseConfig>>[
+      entry.weightConfigs,
+      entry.maxWeightConfigs,
+      entry.repetitionsConfigs,
+      entry.maxRepetitionsConfigs,
+      entry.nrOfSetsConfigs,
+      entry.maxNrOfSetsConfigs,
+      entry.rirConfigs,
+      entry.maxRirConfigs,
+      entry.restTimeConfigs,
+      entry.maxRestTimeConfigs,
+    ];
+
+    for (final configs in allConfigLists) {
+      for (final config in configs) {
+        final parsed = ConfigRequirements.fromMap(config.requirements);
+        if (parsed != null && !parsed.isEmpty) {
+          return parsed;
+        }
+      }
+    }
+
+    return null;
+  }
+
+  String _describe(AppLocalizations i18n, ConfigRequirements? req) {
+    if (req == null) {
+      return i18n.progressionRules;
+    }
+
+    if (req.gatesOnMaxRepetitions && req.allSets) {
+      return i18n.progressionRulesDoubleProgression;
+    }
+
+    if (req.gatesOnMaxRepetitions) {
+      return i18n.progressionRulesGatedOnMaxReps;
+    }
+
+    if (req.gatesOnRepetitions) {
+      return i18n.progressionRulesGatedOnReps;
+    }
+
+    return i18n.progressionRules;
+  }
 
   @override
   Widget build(BuildContext context) {
     final languageCode = Localizations.localeOf(context).languageCode;
     final i18n = AppLocalizations.of(context);
+
+    final activeRequirements = entry != null ? _findActiveRequirements(entry!) : null;
 
     return Column(
       children: [
@@ -24,7 +76,7 @@ class ProgressionRulesInfoBox extends StatelessWidget {
           leading: const Icon(Icons.info),
           tileColor: Theme.of(context).colorScheme.primaryContainer,
           title: Text(
-            i18n.progressionRules,
+            _describe(i18n, activeRequirements),
             style: Theme.of(context).textTheme.bodySmall,
           ),
         ),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1381,6 +1381,18 @@
   "simpleMode": "Simple mode",
   "simpleModeHelp": "Hide some of the more advanced settings when editing exercises",
   "progressionRules": "This exercise has progression rules and can't be edited on the mobile app. Please use the web application to edit this exercise.",
+  "progressionRulesDoubleProgression": "Double progression: weight increases once every set reaches the top of your rep range.",
+  "@progressionRulesDoubleProgression": {
+    "description": "Shown on a routine entry gated on 'max_repetitions' with the all_sets requirement."
+  },
+  "progressionRulesGatedOnMaxReps": "Weight increases once you reach the top of your rep range.",
+  "@progressionRulesGatedOnMaxReps": {
+    "description": "Shown on a routine entry gated on 'max_repetitions' without the all_sets requirement."
+  },
+  "progressionRulesGatedOnReps": "Weight increases once you hit your target reps.",
+  "@progressionRulesGatedOnReps": {
+    "description": "Shown on a routine entry gated on the base 'repetitions' rule."
+  },
   "cacheWarning": "Due to caching it might take some time till the changes are visible throughout the application.",
   "textPromptTitle": "Ready to start?",
   "textPromptSubheading": "Press the action button to begin",

--- a/test/features/routines/models/requirement_rules_test.dart
+++ b/test/features/routines/models/requirement_rules_test.dart
@@ -1,0 +1,100 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:wger/features/routines/models/requirement_rules.dart';
+
+void main() {
+  group('RequirementRuleParsing', () {
+    test('apiValue round-trips every enum value', () {
+      for (final rule in RequirementRule.values) {
+        expect(RequirementRuleParsing.fromApiValue(rule.apiValue), rule);
+      }
+    });
+
+    test('fromApiValue returns null for an unrecognized string', () {
+      expect(RequirementRuleParsing.fromApiValue('some_future_rule'), isNull);
+    });
+
+    test('fromApiValue maps max_repetitions to RequirementRule.maxRepetitions', () {
+      expect(
+        RequirementRuleParsing.fromApiValue('max_repetitions'),
+        RequirementRule.maxRepetitions,
+      );
+    });
+  });
+
+  group('ConfigRequirements.fromMap', () {
+    test('returns null when requirements is null (plain ungated config)', () {
+      expect(ConfigRequirements.fromMap(null), isNull);
+    });
+
+    test('parses an empty rules list as isEmpty', () {
+      final result = ConfigRequirements.fromMap({'rules': <String>[]});
+
+      expect(result, isNotNull);
+      expect(result!.isEmpty, isTrue);
+      expect(result.allSets, isFalse);
+    });
+
+    test('parses the double-progression payload', () {
+      final result = ConfigRequirements.fromMap({
+        'rules': ['max_repetitions'],
+        'all_sets': true,
+      });
+
+      expect(result!.rules, [RequirementRule.maxRepetitions]);
+      expect(result.allSets, isTrue);
+      expect(result.gatesOnMaxRepetitions, isTrue);
+      expect(result.gatesOnRepetitions, isFalse);
+    });
+
+    test('parses a simple gated-on-repetitions payload', () {
+      final result = ConfigRequirements.fromMap({
+        'rules': ['repetitions'],
+      });
+
+      expect(result!.gatesOnRepetitions, isTrue);
+      expect(result.gatesOnMaxRepetitions, isFalse);
+      expect(result.allSets, isFalse);
+    });
+
+    test('defaults all_sets to false when the key is missing', () {
+      final result = ConfigRequirements.fromMap({
+        'rules': ['max_repetitions'],
+      });
+
+      expect(result!.allSets, isFalse);
+    });
+
+    test('coerces a non-boolean all_sets value to false', () {
+      final result = ConfigRequirements.fromMap({
+        'rules': ['max_repetitions'],
+        'all_sets': 'true',
+      });
+
+      expect(result!.allSets, isFalse);
+    });
+
+    test('drops unrecognized rule strings instead of throwing', () {
+      final result = ConfigRequirements.fromMap({
+        'rules': ['max_repetitions', 'unrecognized_rule'],
+      });
+
+      expect(result!.rules, [RequirementRule.maxRepetitions]);
+    });
+
+    test('ignores non-string entries in the rules list', () {
+      final result = ConfigRequirements.fromMap({
+        'rules': ['max_repetitions', 42, null],
+      });
+
+      expect(result!.rules, [RequirementRule.maxRepetitions]);
+    });
+
+    test('handles a missing rules key as an empty rule list', () {
+      final result = ConfigRequirements.fromMap({'all_sets': true});
+
+      expect(result!.rules, isEmpty);
+      expect(result.isEmpty, isTrue);
+      expect(result.allSets, isTrue);
+    });
+  });
+}

--- a/test/features/routines/models/slot_entry_model_test.dart
+++ b/test/features/routines/models/slot_entry_model_test.dart
@@ -72,6 +72,16 @@ void main() {
     expect(slotEntry.hasProgressionRules, true);
   });
 
+  test('hasProgressionRules stays true after removing the duplicated branch', () {
+    // Regression test for the removed duplicate code: previously
+    // `maxWeightConfigs.length > 1` appeared twice in the OR chain.
+    final slotEntry = SlotEntry.empty();
+    slotEntry.maxWeightConfigs.add(BaseConfig.firstIteration(22, 3));
+    slotEntry.maxWeightConfigs.add(BaseConfig.firstIteration(1, 3));
+
+    expect(slotEntry.hasProgressionRules, true);
+  });
+
   test('a single-iteration entry has no progression rules', () {
     final slotEntry = SlotEntry.empty();
     slotEntry.maxWeightConfigs.add(BaseConfig.firstIteration(22, 3));

--- a/test/features/routines/models/slot_entry_model_test.dart
+++ b/test/features/routines/models/slot_entry_model_test.dart
@@ -20,6 +20,7 @@ import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:wger/features/routines/models/base_config.dart';
+import 'package:wger/features/routines/models/requirement_rules.dart';
 import 'package:wger/features/routines/models/slot_entry.dart';
 
 import '../../../../test_data/exercises.dart';
@@ -71,6 +72,50 @@ void main() {
     expect(slotEntry.hasProgressionRules, true);
   });
 
+  test('a single-iteration entry has no progression rules', () {
+    final slotEntry = SlotEntry.empty();
+    slotEntry.maxWeightConfigs.add(BaseConfig.firstIteration(22, 3));
+
+    expect(slotEntry.hasProgressionRules, false);
+  });
+
+  group('reading a gated progression entry from the backend (routine_structure.json)', () {
+    late SlotEntry gatedEntry;
+
+    setUp(() {
+      final apiResponse = fixture('routines/routine_structure.json');
+      final routineJson = json.decode(apiResponse) as Map<String, dynamic>;
+
+      // id: 10 slot entry has weight_configs / max_weight_configs sequence.
+      final armsDay = (routineJson['days'] as List).firstWhere((d) => d['id'] == 10);
+      final entryJson = armsDay['slots'][0]['entries'][0];
+      gatedEntry = SlotEntry.fromJson(entryJson);
+    });
+
+    test('parses all three weight iterations', () {
+      expect(gatedEntry.weightConfigs.length, 3);
+      expect(gatedEntry.weightConfigs[0].iteration, 1);
+      expect(gatedEntry.weightConfigs[1].iteration, 2);
+      expect(gatedEntry.weightConfigs[2].iteration, 8);
+    });
+
+    test('is flagged as having progression rules', () {
+      expect(gatedEntry.hasProgressionRules, true);
+    });
+
+    test('the repeating +1kg step carries an (empty) requirements map, not null', () {
+      final steppingConfig = gatedEntry.weightConfigs[1];
+
+      expect(steppingConfig.repeat, true);
+      expect(steppingConfig.requirements, isNotNull);
+      expect(ConfigRequirements.fromMap(steppingConfig.requirements)!.isEmpty, isTrue);
+    });
+
+    test('getConfigsByType(ConfigType.maxWeight) returns the parsed max_weight_configs list', () {
+      expect(gatedEntry.getConfigsByType(ConfigType.maxWeight), gatedEntry.maxWeightConfigs);
+      expect(gatedEntry.getConfigsByType(ConfigType.maxWeight).length, 3);
+    });
+  });
   group('exercise hydration', () {
     SlotEntry makeEntry() => SlotEntry(
       id: 42,

--- a/test/features/routines/widgets/forms/slot_test.dart
+++ b/test/features/routines/widgets/forms/slot_test.dart
@@ -22,11 +22,15 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:wger/core/network/network_provider.dart';
+import 'package:wger/features/routines/models/base_config.dart';
 import 'package:wger/features/routines/models/slot.dart';
 import 'package:wger/features/routines/models/slot_entry.dart';
 import 'package:wger/features/routines/providers/routines_notifier.dart';
 import 'package:wger/features/routines/providers/routines_repository.dart';
 import 'package:wger/features/routines/widgets/forms/slot.dart';
+import 'package:wger/features/routines/widgets/forms/slot_entry.dart '
+    hide ReorderableSlotList, SlotDetailWidget;
+import 'package:wger/features/routines/widgets/slot.dart';
 import 'package:wger/l10n/generated/app_localizations.dart';
 
 import '../../../../../test_data/routines.dart';
@@ -366,6 +370,141 @@ void main() {
 
       // Only one copy button for the whole group (on the last slot)
       expect(find.byIcon(Icons.content_copy), findsOne);
+    });
+  });
+
+  group('ProgressionRulesInfoBox', () {
+    SlotEntry entryWithRequirements(Map<String, dynamic>? requirements) {
+      final entry = SlotEntry.withData(
+        slotId: 1,
+        exercise: getTestRoutine().days[0].slots[0].entries[0].exerciseObj,
+      );
+      entry.weightConfigs = [
+        BaseConfig.firstIteration(80, 1),
+        BaseConfig(
+          id: null,
+          slotEntryId: 1,
+          iteration: 2,
+          value: 2.5,
+          operation: '+',
+          step: 'abs',
+          repeat: true,
+          requirements: requirements,
+        ),
+      ];
+      return entry;
+    }
+
+    Widget renderInfoBox(SlotEntry entry) {
+      return MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: ProgressionRulesInfoBox(entry.exerciseObj, entry: entry),
+        ),
+      );
+    }
+
+    testWidgets('shows the double-progression message for max_repetitions + all_sets', (
+      tester,
+    ) async {
+      final entry = entryWithRequirements({
+        'rules': ['max_repetitions'],
+        'all_sets': true,
+      });
+
+      await tester.pumpWidget(renderInfoBox(entry));
+      await tester.pumpAndSettle();
+
+      final i18n = AppLocalizations.of(tester.element(find.byType(ProgressionRulesInfoBox)));
+      expect(find.text(i18n.progressionRulesDoubleProgression), findsOneWidget);
+    });
+
+    testWidgets('shows the gated-on-max-reps message without all_sets', (tester) async {
+      final entry = entryWithRequirements({
+        'rules': ['max_repetitions'],
+      });
+
+      await tester.pumpWidget(renderInfoBox(entry));
+      await tester.pumpAndSettle();
+
+      final i18n = AppLocalizations.of(tester.element(find.byType(ProgressionRulesInfoBox)));
+      expect(find.text(i18n.progressionRulesGatedOnMaxReps), findsOneWidget);
+    });
+
+    testWidgets('shows the gated-on-reps message for the repetitions rule', (tester) async {
+      final entry = entryWithRequirements({
+        'rules': ['repetitions'],
+      });
+
+      await tester.pumpWidget(renderInfoBox(entry));
+      await tester.pumpAndSettle();
+
+      final i18n = AppLocalizations.of(tester.element(find.byType(ProgressionRulesInfoBox)));
+      expect(find.text(i18n.progressionRulesGatedOnReps), findsOneWidget);
+    });
+
+    testWidgets('falls back to the generic message for an unconditional repeat', (tester) async {
+      final entry = entryWithRequirements({'rules': <String>[]});
+
+      await tester.pumpWidget(renderInfoBox(entry));
+      await tester.pumpAndSettle();
+
+      final i18n = AppLocalizations.of(tester.element(find.byType(ProgressionRulesInfoBox)));
+      expect(find.text(i18n.progressionRules), findsOneWidget);
+    });
+
+    testWidgets('falls back to the generic message when entry is omitted', (
+      tester,
+    ) async {
+      final exercise = getTestRoutine().days[0].slots[0].entries[0].exerciseObj;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(body: ProgressionRulesInfoBox(exercise)),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final i18n = AppLocalizations.of(tester.element(find.byType(ProgressionRulesInfoBox)));
+      expect(find.text(i18n.progressionRules), findsOneWidget);
+    });
+
+    testWidgets('SlotDetailWidget renders the info box instead of the edit form when gated', (
+      tester,
+    ) async {
+      final routine = getTestRoutine();
+      final gatedEntry = entryWithRequirements({
+        'rules': ['max_repetitions'],
+        'all_sets': true,
+      });
+      final slot = routine.days[0].slots[0];
+      slot.entries[0] = gatedEntry;
+
+      final container = ProviderContainer.test(
+        overrides: [
+          routinesRepositoryProvider.overrideWithValue(MockRoutinesRepository()),
+          networkStatusProvider.overrideWithValue(true),
+          ...routineFormAmbientOverrides(),
+        ],
+      );
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(body: SlotDetailWidget(slot, routine.id!)),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(ProgressionRulesInfoBox), findsOneWidget);
+      expect(find.byType(SlotEntryForm), findsNothing);
     });
   });
 }

--- a/test/features/routines/widgets/forms/slot_test.dart
+++ b/test/features/routines/widgets/forms/slot_test.dart
@@ -28,7 +28,7 @@ import 'package:wger/features/routines/models/slot_entry.dart';
 import 'package:wger/features/routines/providers/routines_notifier.dart';
 import 'package:wger/features/routines/providers/routines_repository.dart';
 import 'package:wger/features/routines/widgets/forms/slot.dart';
-import 'package:wger/features/routines/widgets/forms/slot_entry.dart '
+import 'package:wger/features/routines/widgets/forms/slot_entry.dart'
     hide ReorderableSlotList, SlotDetailWidget;
 import 'package:wger/features/routines/widgets/slot.dart';
 import 'package:wger/l10n/generated/app_localizations.dart';


### PR DESCRIPTION

This pull request Implement  **Double Progression** routines in the Flutter application, matching recent backend capabilities


---

### File Changes Summary

| # | File Path | Change Type | Summary |
| --- | --- | --- | --- |
| 1 | `lib/features/routines/models/requirement_rules.dart` | Added| Added model definitions to parse and handle double progression requirement rules and flags (`all_sets`). |
| 2 | `lib/features/routines/widgets/slot.dart` | Modified | Updated `ProgressionRulesInfoBox` to dynamically render specific double progression guidelines instead of generic text. |
| 3 | `test/features/routines/models/requirement_rules_test.dart` | Added | Added unit tests covering requirement rules serialization and parsing logic. |
| 4 | `test/features/routines/models/slot_entry_model_test.dart` | Modified | Added regression tests |
| 5 | `test/features/routines/widgets/forms/slot_test.dart` | Modified | Updated widget tests for the routine slot form elements under double progression rules. |




## Related Issue(s)

https://github.com/wger-project/wger/issues/2480

## Please check that the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Set a 100-character limit to avoid white space diffs (run `dart format .`)
